### PR TITLE
Add get routes

### DIFF
--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -80,6 +80,12 @@ class TableauxController(override val config: TableauxConfig, override protected
     repository.getRow(tableId, rowId)
   }
 
+  def getRows(tableId: IdType): Future[DomainObject] = {
+    checkArguments(greaterZero(tableId))
+    logger.info(s"getRows $tableId")
+    repository.getRows(tableId)
+  }
+
   def getCell(tableId: IdType, columnId: IdType, rowId: IdType): Future[DomainObject] = {
     checkArguments(greaterZero(tableId), greaterZero(columnId), greaterZero(rowId))
     logger.info(s"getCell $tableId $columnId $rowId")

--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -68,6 +68,12 @@ class TableauxController(override val config: TableauxConfig, override protected
     repository.getColumn(tableId, columnId)
   }
 
+  def getColumns(tableId: IdType): Future[DomainObject] = {
+    checkArguments(greaterZero(tableId))
+    logger.info(s"getColumns $tableId")
+    repository.getColumns(tableId)
+  }
+
   def getRow(tableId: IdType, rowId: IdType): Future[DomainObject] = {
     checkArguments(greaterZero(tableId), greaterZero(rowId))
     logger.info(s"getRow $tableId $rowId")

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -135,6 +135,11 @@ class TableauxModel(override protected[this] val connection: DatabaseConnection)
     (id, seqOfValues) <- rowStruc.get(tableId, rowId)
   } yield Row(table, id, seqOfValues)
 
+  def getRows(tableId: IdType): Future[RowSeq] = for {
+    table <- getTable(tableId)
+    rows <- getAllRows(table)
+  } yield rows
+
   def getCell(tableId: IdType, columnId: IdType, rowId: IdType): Future[Cell[_, _]] = for {
     column <- getColumn(tableId, columnId)
     value <- column match {

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -152,6 +152,11 @@ class TableauxModel(override protected[this] val connection: DatabaseConnection)
     }
   } yield column
 
+  def getColumns(tableId: IdType): Future[ColumnSeq] = for {
+    table <- getTable(tableId)
+    columns <- getAllColumns(table)
+  } yield ColumnSeq(columns)
+
   private def getValueColumn(table: Table, columnId: IdType, columnName: String, columnKind: TableauxDbType, ordering: Ordering): ColumnValue[_] = {
     Mapper.getApply(columnKind).apply(table, columnId, columnName, ordering)
   }

--- a/src/main/scala/com/campudus/tableaux/database/structure/column.scala
+++ b/src/main/scala/com/campudus/tableaux/database/structure/column.scala
@@ -47,7 +47,7 @@ case class LinkColumn[A](table: Table, id: IdType, to: ColumnValue[A], name: Str
 }
 
 case class ColumnSeq(columns: Seq[ColumnType[_]]) extends DomainObject {
-  def getJson: JsonObject = Json.obj("tableId" -> columns.head.table.id, "columns" ->
+  def getJson: JsonObject = Json.obj("columns" ->
     (columns map {
       case c: LinkColumnType[_] => Json.obj("id" -> c.id, "name" -> c.name, "kind" -> c.dbType, "toTable" -> c.to.table.id, "toColumn" -> c.to.id, "ordering" -> c.ordering)
       case c: ColumnValue[_] => Json.obj("id" -> c.id, "name" -> c.name, "kind" -> c.dbType, "ordering" -> c.ordering)

--- a/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
@@ -33,6 +33,7 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
     case Get(TableIdColumnsId(tableId, columnId)) => asyncGetReply(controller.getColumn(tableId.toLong, columnId.toLong))
     case Get(TableIdRowsId(tableId, rowId)) => asyncGetReply(controller.getRow(tableId.toLong, rowId.toLong))
     case Get(TableIdColumnsIdRowsId(tableId, columnId, rowId)) => asyncGetReply(controller.getCell(tableId.toLong, columnId.toLong, rowId.toLong))
+    case Get(TableIdColumns(tableId)) => asyncGetReply(controller.getColumns(tableId.toLong))
 
     case Post("/tables") => asyncSetReply {
       getJson(req) flatMap { json =>

--- a/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
@@ -30,10 +30,11 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
   override def routes(implicit req: HttpServerRequest):  Routing = {
     case Get("/tables") => asyncGetReply(controller.getAllTables())
     case Get(TableId(tableId)) => asyncGetReply(controller.getTable(tableId.toLong))
+    case Get(TableIdColumns(tableId)) => asyncGetReply(controller.getColumns(tableId.toLong))
     case Get(TableIdColumnsId(tableId, columnId)) => asyncGetReply(controller.getColumn(tableId.toLong, columnId.toLong))
+    case Get(TableIdRows(tableId)) => asyncGetReply(controller.getRows(tableId.toLong))
     case Get(TableIdRowsId(tableId, rowId)) => asyncGetReply(controller.getRow(tableId.toLong, rowId.toLong))
     case Get(TableIdColumnsIdRowsId(tableId, columnId, rowId)) => asyncGetReply(controller.getCell(tableId.toLong, columnId.toLong, rowId.toLong))
-    case Get(TableIdColumns(tableId)) => asyncGetReply(controller.getColumns(tableId.toLong))
 
     case Post("/tables") => asyncSetReply {
       getJson(req) flatMap { json =>

--- a/src/test/scala/com/campudus/tableaux/GetTest.scala
+++ b/src/test/scala/com/campudus/tableaux/GetTest.scala
@@ -89,17 +89,32 @@ class GetTest extends TableauxTestBase {
     }
   }
 
-    @Test
-    def getAllTables(): Unit = okTest {
+  @Test
+  def getAllTables(): Unit = okTest {
     val expectedJson = Json.obj("status" -> "ok", "tables" -> Json.arr(
-    Json.obj("id" -> 1, "name" -> "Test Table 1"),
-    Json.obj("id" -> 2, "name" -> "Test Table 2")
+      Json.obj("id" -> 1, "name" -> "Test Table 1"),
+      Json.obj("id" -> 2, "name" -> "Test Table 2")
     ))
 
     for {
       _ <- setupDefaultTable("Test Table 1")
       _ <- setupDefaultTable("Test Table 2")
       test <- sendRequest("GET", "/tables")
+    } yield {
+      assertEquals(expectedJson, test)
+    }
+  }
+
+  @Test
+  def getColumns(): Unit = okTest {
+    val expectedJson = Json.obj("status" -> "ok", "tableId" -> 1, "columns" -> Json.arr(
+      Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1),
+      Json.obj("id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2)
+    ))
+
+    for {
+      _ <- setupDefaultTable()
+      test <- sendRequest("GET", "/tables/1/columns")
     } yield {
       assertEquals(expectedJson, test)
     }

--- a/src/test/scala/com/campudus/tableaux/GetTest.scala
+++ b/src/test/scala/com/campudus/tableaux/GetTest.scala
@@ -107,7 +107,7 @@ class GetTest extends TableauxTestBase {
 
   @Test
   def getColumns(): Unit = okTest {
-    val expectedJson = Json.obj("status" -> "ok", "tableId" -> 1, "columns" -> Json.arr(
+    val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(
       Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1),
       Json.obj("id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2)
     ))

--- a/src/test/scala/com/campudus/tableaux/GetTest.scala
+++ b/src/test/scala/com/campudus/tableaux/GetTest.scala
@@ -157,6 +157,21 @@ class GetTest extends TableauxTestBase {
   }
 
   @Test
+  def getRows(): Unit = okTest {
+    val expectedJson = Json.obj("status" -> "ok", "rows" -> Json.arr(
+      Json.obj("id" -> 1, "values" -> Json.arr("Test Fill 1", 1)),
+      Json.obj("id" -> 2, "values" -> Json.arr("Test Fill 2", 2))
+    ))
+
+    for {
+      _ <- setupDefaultTable()
+      test <- sendRequest("GET", "/tables/1/rows")
+    } yield {
+      assertEquals(expectedJson, test)
+    }
+  }
+
+  @Test
   def getCell(): Unit = okTest {
     val expectedJson = Json.obj("status" -> "ok", "rows" -> Json.arr(Json.obj("value" -> "Test Fill 1")))
     val expectedJson2 = Json.obj("status" -> "ok", "rows" -> Json.arr(Json.obj("value" -> 1)))


### PR DESCRIPTION
Adds two new routes:
- `GET /tables/:id/columns` - retrieves all columns in a table
- `GET /tables/:id/rows` - retrieves all rows in a table

I hope we can then use the new backbone backed frontend.