### PR TITLE
Fix generateProjection() as it could generate a comma on empty lists

### DIFF
--- a/src/main/scala/com/campudus/tableaux/database/DatabaseQuery.scala
+++ b/src/main/scala/com/campudus/tableaux/database/DatabaseQuery.scala
@@ -210,7 +210,11 @@ class RowStructure(val connection: DatabaseConnection) extends DatabaseQuery {
       case c: ColumnType[_] => s"column_${c.id}"
     }
 
-    s"id, ${projection.mkString(",")}"
+    if (projection.nonEmpty) {
+      s"id, ${projection.mkString(",")}"
+    } else {
+      s"id"
+    }
   }
 
   def getAll(tableId: IdType, columns: Seq[ColumnType[_]]): Future[Seq[(IdType, Seq[AnyRef])]] = {


### PR DESCRIPTION
Should fix the two currently failing tests. You may have an empty table without columns in the database -> the SQL might have had a `,` too much.