### PR TITLE
Table ordering

### DIFF
--- a/src/main/scala/com/campudus/tableaux/arguments.scala
+++ b/src/main/scala/com/campudus/tableaux/arguments.scala
@@ -65,7 +65,7 @@ object ArgumentChecker {
 
   def hasNumber(field: String, json: JsonObject): ArgumentCheck[Number] = notNull(json.getValue(field).asInstanceOf[Number], field)
 
-  def hasLong(field: String, json: JsonObject): ArgumentCheck[Long] = notNull(json.getLong(field), field)
+  def hasLong(field: String, json: JsonObject): ArgumentCheck[Long] = notNull(json.getLong(field), field).map(_.longValue())
 
   def hasString(field: String, json: JsonObject): ArgumentCheck[String] = notNull(json.getString(field), field)
 

--- a/src/main/scala/com/campudus/tableaux/arguments.scala
+++ b/src/main/scala/com/campudus/tableaux/arguments.scala
@@ -61,6 +61,14 @@ object ArgumentChecker {
     }
   }
 
+  def oneOf[A](x: => A, list: List[A], name: String): ArgumentCheck[A] = {
+    if (list.contains(x)) {
+      OkArg(x)
+    } else {
+      FailArg(InvalidRequestException(s"'$name' value needs to be one of ${list.mkString("'", "', '", "'")}."))
+    }
+  }
+
   def hasArray(field: String, json: JsonObject): ArgumentCheck[JsonArray] = notNull(json.getJsonArray(field), field)
 
   def hasNumber(field: String, json: JsonObject): ArgumentCheck[Number] = notNull(json.getValue(field).asInstanceOf[Number], field)

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -110,6 +110,20 @@ class StructureController(override val config: TableauxConfig, override protecte
     }
   }
 
+  def changeTableOrder(tableId: TableId, location: String, id: Option[Long]): Future[EmptyObject] = {
+    checkArguments(notNull(location, "location"), oneOf(location, List("start", "end", "before"), "location"))
+
+    if ("before" == location) {
+      checkArguments(isDefined(id, "id"))
+    }
+
+    logger.info(s"changeTableOrder $tableId $location $id")
+
+    for {
+      _ <- tableStruc.changeOrder(tableId, location, id)
+    } yield EmptyObject()
+  }
+
   def changeColumn(tableId: TableId, columnId: ColumnId, columnName: Option[String], ordering: Option[Ordering], kind: Option[TableauxDbType], identifier: Option[Boolean]): Future[ColumnType[_]] = {
     checkArguments(greaterZero(tableId), greaterZero(columnId))
     logger.info(s"changeColumn $tableId $columnId $columnName $ordering $kind")

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -115,7 +115,8 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
   private val setupFunctions = Seq(
     setupVersion1(_),
     setupVersion2(_),
-    setupVersion3(_)
+    setupVersion3(_),
+    setupVersion4(_)
   )
 
   private def saveVersion(t: connection.Transaction, version: Int): Future[connection.Transaction] = {
@@ -284,6 +285,21 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
            |""".stripMargin)
 
       t <- saveVersion(t, 3)
+    } yield t
+  }
+
+  private def setupVersion4(t: connection.Transaction): Future[connection.Transaction] = {
+    logger.info("Setup schema version 4")
+
+    for {
+      (t, _) <- t.query(
+        s"""
+           |ALTER TABLE system_table
+           |ADD COLUMN
+           |ordering BIGINT DEFAULT currval('system_table_table_id_seq')
+           |""".stripMargin)
+
+      t <- saveVersion(t, 4)
     } yield t
   }
 }

--- a/src/main/scala/com/campudus/tableaux/router/BaseRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/BaseRouter.scala
@@ -54,6 +54,7 @@ trait BaseRouter extends Router with VertxAccess with LazyLogging {
         Ok(replyBody)
     } recover {
       case ex: CustomException => Error(RouterException(ex.message, ex, ex.id, ex.statusCode))
+      case ex: IllegalArgumentException => Error(RouterException(ex.getMessage, ex, "error.arguments", 422))
       case ex: Throwable => Error(RouterException("unknown error", ex, "error.unknown", 500))
     }
 

--- a/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
@@ -21,6 +21,7 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
 
   private val Table: Regex = "/tables/(\\d+)".r
   private val Tables: Regex = "/tables".r
+  private val TableOrder: Regex = "/tables/(\\d+)/order".r
 
   override def routes(implicit context: RoutingContext): Routing = {
     case Get(Tables()) => asyncGetReply(controller.retrieveTables())
@@ -59,6 +60,16 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
       getJson(context) flatMap { json =>
         controller.changeTable(tableId.toLong, Option(json.getString("name")), Option(json.getBoolean("hidden")).map(_.booleanValue()))
       }
+    }
+
+    /**
+      * Change Table ordering
+      */
+    case Post(TableOrder(tableId)) => asyncEmptyReply {
+      for {
+        json <- getJson(context)
+        result <- controller.changeTableOrder(tableId.toLong, json.getString("location"), Option(json.getLong("id")).map(_.toLong))
+      } yield result
     }
 
     /**

--- a/src/test/scala/com/campudus/tableaux/ArgumentCheckerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/ArgumentCheckerTest.scala
@@ -91,4 +91,17 @@ class ArgumentCheckerTest {
       case _: Throwable => fail(s"Should throw an IllegalArgumentException")
     }
   }
+
+  @Test
+  def checkOneOf(): Unit = {
+    checkArguments(oneOf("b", List("a", "b", "c"), "oneof"))
+
+    try {
+      checkArguments(oneOf("d", List("a", "b", "c"), "oneof"))
+      fail("Should throw an exception")
+    } catch {
+      case ex: IllegalArgumentException => assertEquals("(0) 'oneof' value needs to be one of 'a', 'b', 'c'.", ex.getMessage)
+      case _: Throwable => fail("Should throw an IllegalArgumentException")
+    }
+  }
 }

--- a/src/test/scala/com/campudus/tableaux/MediaTest.scala
+++ b/src/test/scala/com/campudus/tableaux/MediaTest.scala
@@ -541,7 +541,7 @@ class MediaTest extends TableauxTestBase {
   }
 
   @Test
-  def addAttachmentWithMalformedUUID(implicit c: TestContext): Unit = exceptionTest("error.unknown") {
+  def addAttachmentWithMalformedUUID(implicit c: TestContext): Unit = exceptionTest("error.arguments") {
     val column = Json.obj("columns" -> Json.arr(Json.obj(
       "kind" -> "attachment",
       "name" -> "Downloads"

--- a/src/test/scala/com/campudus/tableaux/TableOrderingTest.scala
+++ b/src/test/scala/com/campudus/tableaux/TableOrderingTest.scala
@@ -1,0 +1,66 @@
+package com.campudus.tableaux
+
+import io.vertx.ext.unit.TestContext
+import io.vertx.ext.unit.junit.VertxUnitRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.vertx.scala.core.json.Json
+
+import scala.concurrent.Future
+
+@RunWith(classOf[VertxUnitRunner])
+class TableOrderingTest extends TableauxTestBase {
+
+  private def createEmptyTable(name: String) = {
+    sendRequest("POST", "/tables", Json.obj("name" -> name)).map(_.getLong("id"))
+  }
+
+  private def regularTableJson(id: Long, name: String) = Json.obj("id" -> id, "name" -> name, "hidden" -> false)
+
+  @Test
+  def createTablesShouldStayInOrderOfCreation(implicit c: TestContext): Unit = okTest {
+    for {
+      tableId1 <- createEmptyTable("First")
+      tableId2 <- createEmptyTable("Second")
+      tableId3 <- createEmptyTable("Third")
+      tableId4 <- createEmptyTable("Fourth")
+      tableId5 <- createEmptyTable("Fifth")
+      tables <- sendRequest("GET", "/tables")
+    } yield {
+
+      val expected = Json.obj("status" -> "ok", "tables" -> Json.arr(
+        regularTableJson(1, "First"),
+        regularTableJson(2, "Second"),
+        regularTableJson(3, "Third"),
+        regularTableJson(4, "Fourth"),
+        regularTableJson(5, "Fifth")
+      ))
+
+      assertEquals(expected, tables)
+    }
+  }
+
+  @Test
+  def orderTableCanBeSetToStart(implicit c: TestContext): Unit = okTest {
+    for {
+      tableId1 <- createEmptyTable("First")
+      tableId2 <- createEmptyTable("Second")
+      tableId3 <- createEmptyTable("Third")
+      tableId4 <- createEmptyTable("Fourth")
+      tableId5 <- createEmptyTable("Fifth")
+      orderResult <- sendRequest("POST", s"/tables/$tableId5/order", Json.obj("location" -> "start"))
+      tables <- sendRequest("GET", "/tables")
+    } yield {
+
+      val expected = Json.obj("status" -> "ok", "tables" -> Json.arr(
+        regularTableJson(5, "Fifth"),
+        regularTableJson(1, "First"),
+        regularTableJson(2, "Second"),
+        regularTableJson(3, "Third"),
+        regularTableJson(4, "Fourth")
+      ))
+
+      assertEquals(expected, tables)
+    }
+  }
+}

--- a/src/test/scala/com/campudus/tableaux/TableOrderingTest.scala
+++ b/src/test/scala/com/campudus/tableaux/TableOrderingTest.scala
@@ -48,11 +48,16 @@ class TableOrderingTest extends TableauxTestBase {
       tableId3 <- createEmptyTable("Third")
       tableId4 <- createEmptyTable("Fourth")
       tableId5 <- createEmptyTable("Fifth")
-      orderResult <- sendRequest("POST", s"/tables/$tableId5/order", Json.obj("location" -> "start"))
-      tables <- sendRequest("GET", "/tables")
+      orderResult1 <- sendRequest("POST", s"/tables/$tableId5/order", Json.obj("location" -> "start"))
+      tables1 <- sendRequest("GET", "/tables")
+      orderResult2 <- sendRequest("POST", s"/tables/$tableId3/order", Json.obj("location" -> "start"))
+      tables2 <- sendRequest("GET", "/tables")
     } yield {
 
-      val expected = Json.obj("status" -> "ok", "tables" -> Json.arr(
+      assertEquals(Json.obj("status" -> "ok"), orderResult1)
+      assertEquals(Json.obj("status" -> "ok"), orderResult2)
+
+      val expected1 = Json.obj("status" -> "ok", "tables" -> Json.arr(
         regularTableJson(5, "Fifth"),
         regularTableJson(1, "First"),
         regularTableJson(2, "Second"),
@@ -60,7 +65,166 @@ class TableOrderingTest extends TableauxTestBase {
         regularTableJson(4, "Fourth")
       ))
 
-      assertEquals(expected, tables)
+      assertEquals(expected1, tables1)
+
+      val expected2 = Json.obj("status" -> "ok", "tables" -> Json.arr(
+        regularTableJson(3, "Third"),
+        regularTableJson(5, "Fifth"),
+        regularTableJson(1, "First"),
+        regularTableJson(2, "Second"),
+        regularTableJson(4, "Fourth")
+      ))
+
+      assertEquals(expected2, tables2)
     }
   }
+
+  @Test
+  def orderTableCanBeSetToEnd(implicit c: TestContext): Unit = okTest {
+    for {
+      tableId1 <- createEmptyTable("First")
+      tableId2 <- createEmptyTable("Second")
+      tableId3 <- createEmptyTable("Third")
+      tableId4 <- createEmptyTable("Fourth")
+      tableId5 <- createEmptyTable("Fifth")
+      orderResult1 <- sendRequest("POST", s"/tables/$tableId1/order", Json.obj("location" -> "end"))
+      tables1 <- sendRequest("GET", "/tables")
+      orderResult2 <- sendRequest("POST", s"/tables/$tableId3/order", Json.obj("location" -> "end"))
+      tables2 <- sendRequest("GET", "/tables")
+    } yield {
+
+      assertEquals(Json.obj("status" -> "ok"), orderResult1)
+      assertEquals(Json.obj("status" -> "ok"), orderResult2)
+
+      val expected1 = Json.obj("status" -> "ok", "tables" -> Json.arr(
+        regularTableJson(2, "Second"),
+        regularTableJson(3, "Third"),
+        regularTableJson(4, "Fourth"),
+        regularTableJson(5, "Fifth"),
+        regularTableJson(1, "First")
+      ))
+
+      assertEquals(expected1, tables1)
+
+      val expected2 = Json.obj("status" -> "ok", "tables" -> Json.arr(
+        regularTableJson(2, "Second"),
+        regularTableJson(4, "Fourth"),
+        regularTableJson(5, "Fifth"),
+        regularTableJson(1, "First"),
+        regularTableJson(3, "Third")
+      ))
+
+      assertEquals(expected2, tables2)
+    }
+  }
+
+  @Test
+  def orderTableCanBeSetToBefore(implicit c: TestContext): Unit = okTest {
+    for {
+      tableId1 <- createEmptyTable("First")
+      tableId2 <- createEmptyTable("Second")
+      tableId3 <- createEmptyTable("Third")
+      tableId4 <- createEmptyTable("Fourth")
+      tableId5 <- createEmptyTable("Fifth")
+      orderResult1 <- sendRequest("POST", s"/tables/$tableId1/order", Json.obj("location" -> "before", "id" -> tableId3))
+      tables1 <- sendRequest("GET", "/tables")
+      orderResult2 <- sendRequest("POST", s"/tables/$tableId3/order", Json.obj("location" -> "before", "id" -> tableId5))
+      tables2 <- sendRequest("GET", "/tables")
+    } yield {
+
+      assertEquals(Json.obj("status" -> "ok"), orderResult1)
+      assertEquals(Json.obj("status" -> "ok"), orderResult2)
+
+      val expected1 = Json.obj("status" -> "ok", "tables" -> Json.arr(
+        regularTableJson(2, "Second"),
+        regularTableJson(1, "First"),
+        regularTableJson(3, "Third"),
+        regularTableJson(4, "Fourth"),
+        regularTableJson(5, "Fifth")
+      ))
+
+      assertEquals(expected1, tables1)
+
+      val expected2 = Json.obj("status" -> "ok", "tables" -> Json.arr(
+        regularTableJson(2, "Second"),
+        regularTableJson(1, "First"),
+        regularTableJson(4, "Fourth"),
+        regularTableJson(3, "Third"),
+        regularTableJson(5, "Fifth")
+      ))
+
+      assertEquals(expected2, tables2)
+    }
+  }
+
+  @Test
+  def orderTableBeforeWithoutId(implicit c: TestContext): Unit = okTest {
+    for {
+      tableId1 <- createEmptyTable("First")
+      tableId2 <- createEmptyTable("Second")
+      orderResult <- sendRequest("POST", s"/tables/$tableId1/order", Json.obj("location" -> "before")) recover {
+        case TestCustomException(message, id, statusCode) =>
+          (message, id, statusCode)
+      }
+      tables1 <- sendRequest("GET", "/tables")
+    } yield {
+
+      assertEquals(("(0) query parameter id not found", "error.arguments", 422), orderResult)
+
+      val expected1 = Json.obj("status" -> "ok", "tables" -> Json.arr(
+        regularTableJson(1, "First"),
+        regularTableJson(2, "Second")
+      ))
+
+      assertEquals(expected1, tables1)
+    }
+  }
+
+  @Test
+  def orderTableWithInvalidLocation(implicit c: TestContext): Unit = okTest {
+    for {
+      tableId1 <- createEmptyTable("First")
+      tableId2 <- createEmptyTable("Second")
+      orderResult <- sendRequest("POST", s"/tables/$tableId1/order", Json.obj("location" -> "blubb")) recover {
+        case TestCustomException(message, id, statusCode) =>
+          (message, id, statusCode)
+      }
+      tables1 <- sendRequest("GET", "/tables")
+    } yield {
+
+      assertEquals(("(1) 'location' value needs to be one of 'start', 'end', 'before'.", "error.arguments", 422), orderResult)
+
+      val expected1 = Json.obj("status" -> "ok", "tables" -> Json.arr(
+        regularTableJson(1, "First"),
+        regularTableJson(2, "Second")
+      ))
+
+      assertEquals(expected1, tables1)
+    }
+  }
+
+  @Test
+  def orderTableWithNullLocation(implicit c: TestContext): Unit = okTest {
+    for {
+      tableId1 <- createEmptyTable("First")
+      tableId2 <- createEmptyTable("Second")
+      orderResult <- sendRequest("POST", s"/tables/$tableId1/order", Json.obj("id" -> 2)) recover {
+        case TestCustomException(message, id, statusCode) =>
+          (message, id, statusCode)
+      }
+      tables1 <- sendRequest("GET", "/tables")
+    } yield {
+
+      assertEquals(("(0) Warning: location is null\n" +
+        "(1) 'location' value needs to be one of 'start', 'end', 'before'.", "error.arguments", 422), orderResult)
+
+      val expected1 = Json.obj("status" -> "ok", "tables" -> Json.arr(
+        regularTableJson(1, "First"),
+        regularTableJson(2, "Second")
+      ))
+
+      assertEquals(expected1, tables1)
+    }
+  }
+
 }

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -64,8 +64,8 @@ class SystemControllerTest extends TableauxTestBase {
       "versions" -> Json.obj(
         "implementation" -> "DEVELOPMENT",
         "database" -> Json.obj(
-          "current" -> 3,
-          "specification" -> 3
+          "current" -> 4,
+          "specification" -> 4
         )
       ),
       "status" -> "ok"


### PR DESCRIPTION
* Catch `IllegalArgumentException`s to return better error messages to clients
* Add `oneOf` `ArgumentCheck` to check if something is contained in a predefined list of values
* Add `start`, `end` and `before` as possible options to sort a table.

I didn't add `after` yet, but that might be a good addition if I still find some time tonight. Guess we need it once pagination is available?

Thanks for reviewing, @alexvetter !