### PR TITLE
Link identification

### DIFF
--- a/src/main/scala/com/campudus/tableaux/arguments.scala
+++ b/src/main/scala/com/campudus/tableaux/arguments.scala
@@ -40,6 +40,13 @@ object ArgumentChecker {
     case cce: ClassCastException => FailArg(InvalidJsonException(s"Warning: $name should be another type. Error: ${cce.getMessage}", "invalid"))
   }
 
+  def greaterThan(x: Long, than: Long, name: String): ArgumentCheck[Long] = {
+    if (x > than)
+      OkArg(x)
+    else
+      FailArg(InvalidJsonException(s"Argument $name ($x) is less than $than.", "invalid"))
+  }
+
   def greaterZero(x: Long): ArgumentCheck[Long] = if (x > 0) OkArg(x) else FailArg(InvalidJsonException(s"Argument $x is not greater than zero", "invalid"))
 
   def nonEmpty[A](seq: Seq[A], name: String): ArgumentCheck[Seq[A]] = {

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -47,7 +47,7 @@ class StructureController(override val config: TableauxConfig, override protecte
   }
 
   def retrieveColumn(tableId: TableId, columnId: ColumnId): Future[ColumnType[_]] = {
-    checkArguments(greaterZero(tableId), greaterZero(columnId))
+    checkArguments(greaterZero(tableId), greaterThan(columnId, -1, "columnId"))
     logger.info(s"retrieveColumn $tableId $columnId")
 
     for {

--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -64,7 +64,7 @@ class TableauxController(override val config: TableauxConfig, override protected
   }
 
   def retrieveCell(tableId: TableId, columnId: ColumnId, rowId: ColumnId): Future[DomainObject] = {
-    checkArguments(greaterZero(tableId), greaterZero(columnId), greaterZero(rowId))
+    checkArguments(greaterZero(tableId), greaterThan(columnId, -1, "columnId"), greaterZero(rowId))
     logger.info(s"retrieveCell $tableId $columnId $rowId")
     repository.retrieveCell(tableId, columnId, rowId)
   }

--- a/src/main/scala/com/campudus/tableaux/database/domain/column.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/column.scala
@@ -113,7 +113,7 @@ case class AttachmentColumn(table: Table, id: ColumnId, name: String, ordering: 
   override val multilanguage = false
 }
 
-case class ConcatColumn(table: Table, name: String, columns: Seq[ColumnType[_]]) extends ColumnType[String] {
+case class ConcatColumn(table: Table, name: String, columns: Seq[ColumnType[_]]) extends ValueColumn[String] {
   override val kind = ConcatType
 
   // ConcatColumn will be a multi-language

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -7,7 +7,6 @@ import com.campudus.tableaux.database.domain._
 import com.campudus.tableaux.database.model.tableaux.{CellModel, RowModel}
 import com.campudus.tableaux.helper.JsonUtils
 import com.campudus.tableaux.{ArgumentChecker, InvalidJsonException}
-import io.vertx.core.json.JsonArray
 import org.vertx.scala.core.json._
 
 import scala.concurrent.Future
@@ -317,6 +316,24 @@ class TableauxModel(override protected[this] val connection: DatabaseConnection)
       case (rowId, rawValues) =>
 
         val mergedValues = Future.sequence((columns, rawValues).zipped map {
+          case (c: LinkColumn[_], value) if c.to.isInstanceOf[ConcatColumn] =>
+            import scala.collection.JavaConversions._
+            import scala.collection.JavaConverters._
+
+            // ConcatColumn's value is always a
+            // json array with the linked row ids
+            val array = value.asInstanceOf[JsonArray]
+
+            // Iterate over each linked row and
+            // replace json's value with ConcatColumn value
+            Future.sequence(array.toList.map({
+              case obj: JsonObject =>
+                val rowId = obj.getLong("id").longValue()
+                retrieveCell(c.to, rowId).map({
+                  cell =>
+                    Json.obj("id" -> rowId, "value" -> cell.value)
+                })
+            })).map(_.asJava)
           case (c: AttachmentColumn, _) => attachmentModel.retrieveAll(c.table.id, c.id, rowId)
           case (_, value) => Future(value)
         })

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
@@ -126,6 +126,18 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
   }
 
   def retrieve(tableId: TableId, columnId: ColumnId): Future[ColumnType[_]] = {
+    columnId match {
+      case 0 =>
+        // Column zero could only be a concat column.
+        // We need to retrieve all columns, because
+        // only then the ConcatColumn is generated.
+        retrieveAll(tableId).map(_.head)
+      case _ =>
+        retrieveOne(tableId, columnId)
+    }
+  }
+
+  private def retrieveOne(tableId: TableId, columnId: ColumnId): Future[ColumnType[_]] = {
     val select = "SELECT column_id, user_column_name, column_type, ordering, multilanguage, identifier FROM system_columns WHERE table_id = ? AND column_id = ?"
     for {
       result <- {

--- a/src/test/scala/com/campudus/tableaux/IdentifierTest.scala
+++ b/src/test/scala/com/campudus/tableaux/IdentifierTest.scala
@@ -43,10 +43,31 @@ class IdentifierTest extends TableauxTestBase {
     } yield {
       // in case of two or more identifier columns we preserve the order of column
       // and a concatcolumn in front of all columns
-      assertEquals(Json.arr(1,3), test.getJsonArray("columns").get[JsonObject](0).getJsonArray("concats"))
+      assertEquals(Json.arr(1, 3), test.getJsonArray("columns").get[JsonObject](0).getJsonArray("concats"))
 
       assertEquals(1, test.getJsonArray("columns").get[JsonObject](1).getInteger("id"))
       assertEquals(3, test.getJsonArray("columns").get[JsonObject](3).getInteger("id"))
+    }
+  }
+
+  @Test
+  def retrieveConcatColumn(implicit c: TestContext): Unit = okTest {
+    val createStringColumnJson = Json.obj("columns" -> Json.arr(Json.obj("kind" -> "text", "name" -> "Test Column 3")))
+
+    for {
+      _ <- setupDefaultTable()
+
+      // create a third column
+      _ <- sendRequest("POST", s"/tables/1/columns", createStringColumnJson)
+
+      // make the first and the last an identifier column
+      _ <- sendRequest("POST", "/tables/1/columns/1", Json.obj("identifier" -> true))
+      _ <- sendRequest("POST", "/tables/1/columns/3", Json.obj("identifier" -> true))
+
+      test <- sendRequest("GET", "/tables/1/columns/0")
+    } yield {
+      assertEquals(Json.arr(1, 3), test.getJsonArray("concats"))
+      assertEquals("concat", test.getString("kind"))
     }
   }
 
@@ -64,11 +85,12 @@ class IdentifierTest extends TableauxTestBase {
       )
     )
 
+    val expectedCellValue = Json.arr("table1row1", 1, Json.emptyArr())
     val expectedJson = Json.obj(
       "status" -> "ok",
       "id" -> 1,
       "values" -> Json.arr(
-        Json.arr("table1row1", 1, Json.emptyArr()),
+        expectedCellValue,
         "table1row1",
         1,
         Json.emptyArr()
@@ -88,15 +110,17 @@ class IdentifierTest extends TableauxTestBase {
       _ <- sendRequest("POST", "/tables/1/columns/2", Json.obj("identifier" -> true))
       _ <- sendRequest("POST", "/tables/1/columns/3", Json.obj("identifier" -> true))
 
-      test <- sendRequest("GET", "/tables/1/rows/1")
+      testRow <- sendRequest("GET", "/tables/1/rows/1")
+      testCell <- sendRequest("GET", "/tables/1/columns/0/rows/1")
     } yield {
-      assertEquals(expectedJson, test)
+      assertEquals(expectedJson, testRow)
+      assertEquals(expectedCellValue, testCell.getJsonArray("value"))
     }
   }
 
   @Test
   def retrieveRowWithMultiLanguageIdentifierColumn(implicit c: TestContext): Unit = okTest {
-    val linkColumn = Json.obj(
+    val linkColumnToTable2 = Json.obj(
       "columns" -> Json.arr(
         Json.obj(
           "name" -> "Test Link 1",
@@ -104,6 +128,18 @@ class IdentifierTest extends TableauxTestBase {
           "fromColumn" -> 1,
           "toTable" -> 2,
           "toColumn" -> 3
+        )
+      )
+    )
+
+    val linkColumnToTable3 = Json.obj(
+      "columns" -> Json.arr(
+        Json.obj(
+          "name" -> "Test Link 1",
+          "kind" -> "link",
+          "fromColumn" -> 1,
+          "toTable" -> 3,
+          "toColumn" -> 1
         )
       )
     )
@@ -118,27 +154,19 @@ class IdentifierTest extends TableauxTestBase {
       )
     )
 
+    val expectedCellValue = Json.arr(
+      "table1row1",
+      1,
+      Json.obj(
+        "de-DE" -> "Tschüss",
+        "en-US" -> "Goodbye"
+      )
+    )
     val expectedJson = Json.obj(
       "status" -> "ok",
       "id" -> 1,
       "values" -> Json.arr(
-        Json.arr(
-          "table1row1",
-          1,
-          Json.obj(
-            "de-DE" -> "Tschüss",
-            "en-US" -> "Goodbye"
-          ),
-          Json.arr(
-            Json.obj(
-              "id" -> 1,
-              "value" -> Json.obj(
-                "de-DE" -> "Hallo",
-                "en-US" -> "Hello"
-              )
-            )
-          )
-        ),
+        expectedCellValue,
         "table1row1",
         1,
         Json.obj(
@@ -148,9 +176,14 @@ class IdentifierTest extends TableauxTestBase {
         Json.arr(
           Json.obj(
             "id" -> 1,
-            "value" -> Json.obj(
-              "de-DE" -> "Hallo",
-              "en-US" -> "Hello"
+            "value" -> Json.arr(
+              "table2row1",
+              Json.arr(
+                Json.obj(
+                  "id" -> 1,
+                  "value" -> "table3row1"
+                )
+              )
             )
           )
         )
@@ -160,33 +193,44 @@ class IdentifierTest extends TableauxTestBase {
     for {
       table1 <- setupDefaultTable()
       table2 <- setupDefaultTable("Test Table 2", 2)
+      table3 <- setupDefaultTable("Test Table 3", 3)
 
-      table2column3 <- sendRequest("POST", "/tables/2/columns", multilangTextColumn) map {
-        _.getArray("columns").get[JsonObject](0).getLong("id")
-      }
-
+      // create multi-language column and fill cell
       table1column3 <- sendRequest("POST", "/tables/1/columns", multilangTextColumn) map {
         _.getArray("columns").get[JsonObject](0).getLong("id")
       }
-
-      // create link column
-      table1column4 <- sendRequest("POST", "/tables/1/columns", linkColumn) map {
-        _.getArray("columns").get[JsonObject](0).getLong("id")
-      }
-
-      _ <- sendRequest("POST", "/tables/2/columns/3/rows/1", Json.obj("value" -> Json.obj("de-DE" -> "Hallo", "en-US" -> "Hello")))
       _ <- sendRequest("POST", "/tables/1/columns/3/rows/1", Json.obj("value" -> Json.obj("de-DE" -> "Tschüss", "en-US" -> "Goodbye")))
 
+      // create multi-language column and fill cell
+      table2column3 <- sendRequest("POST", "/tables/2/columns", multilangTextColumn) map {
+        _.getArray("columns").get[JsonObject](0).getLong("id")
+      }
+      _ <- sendRequest("POST", "/tables/2/columns/3/rows/1", Json.obj("value" -> Json.obj("de-DE" -> "Hallo", "en-US" -> "Hello")))
+
+      // create link column, which will link to concatcolumn in this case
+      table1column4 <- sendRequest("POST", "/tables/1/columns", linkColumnToTable2) map {
+        _.getArray("columns").get[JsonObject](0).getLong("id")
+      }
       _ <- sendRequest("PUT", "/tables/1/columns/4/rows/1", Json.obj("value" -> Json.obj("from" -> 1, "to" -> 1)))
+
+      // create link column, which will link to concatcolumn in this case
+      table2column5 <- sendRequest("POST", "/tables/2/columns", linkColumnToTable3) map {
+        _.getArray("columns").get[JsonObject](0).getLong("id")
+      }
+      _ <- sendRequest("PUT", "/tables/2/columns/5/rows/1", Json.obj("value" -> Json.obj("from" -> 1, "to" -> 1)))
 
       _ <- sendRequest("POST", "/tables/1/columns/1", Json.obj("identifier" -> true))
       _ <- sendRequest("POST", "/tables/1/columns/2", Json.obj("identifier" -> true))
       _ <- sendRequest("POST", "/tables/1/columns/3", Json.obj("identifier" -> true))
-      _ <- sendRequest("POST", "/tables/1/columns/4", Json.obj("identifier" -> true))
 
-      test <- sendRequest("GET", "/tables/1/rows/1")
+      _ <- sendRequest("POST", "/tables/2/columns/1", Json.obj("identifier" -> true))
+      _ <- sendRequest("POST", "/tables/2/columns/5", Json.obj("identifier" -> true))
+
+      testRow <- sendRequest("GET", "/tables/1/rows/1")
+      testCell <- sendRequest("GET", "/tables/1/columns/0/rows/1")
     } yield {
-      assertEquals(expectedJson, test)
+      assertEquals(expectedJson, testRow)
+      assertEquals(expectedCellValue, testCell.getJsonArray("value"))
     }
   }
 }


### PR DESCRIPTION
* `ConcatColumn` definition can be retrieved (`GET /tables/1/columns/0`)
* Cell value of a `ConcatColumn` can be retrieved (`GET /tables/1/columns/0/rows/1`)
* New behaviour for `LinkColumn`. If it points at a table with a `ConcatColumn` (more than one identifier column) the link value will be the `ConcatColumn` value. If there one but only one identifier column the link value will be the identifier column's value.

More notes: TBD.