### PR TITLE
Add patch route for cells

### DIFF
--- a/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
@@ -121,6 +121,15 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
     }
 
     /**
+      * Update Cell
+      */
+    case Patch(Cell(tableId, columnId, rowId)) => asyncSetReply {
+      getJson(context) flatMap { json =>
+        controller.updateCell(tableId.toLong, columnId.toLong, rowId.toLong, json.getValue("value"))
+      }
+    }
+
+    /**
       * Delete Row
       */
     case Delete(Row(tableId, rowId)) => asyncEmptyReply(controller.deleteRow(tableId.toLong, rowId.toLong))


### PR DESCRIPTION
To update multilanguage cells (and later, hopefully links, attachments, etc.), we want to introduce the `PATCH` route.

Right now, it's a copy/paste of `PUT` cell. In the future, we kick `POST` and use `PUT` for overriding the complete values. With `PATCH` we add, update or delete values of a complex type like links, attachments and multilanguage values.