### PR TITLE
Link refactoring

### DIFF
--- a/src/main/resources/demodata/bundeslaender.json
+++ b/src/main/resources/demodata/bundeslaender.json
@@ -3,7 +3,8 @@
   "columns" : [ {
     "kind" : "text",
     "name" : "Land",
-    "ordering" : 1
+    "ordering" : 1,
+    "identifier" : true
   }, {
     "kind" : "text",
     "name" : "Hauptstadt",

--- a/src/main/resources/demodata/regierungsbezirke.json
+++ b/src/main/resources/demodata/regierungsbezirke.json
@@ -3,7 +3,8 @@
   "columns" : [ {
     "kind" : "text",
     "name" : "Regierungsbezirk",
-    "ordering" : 1
+    "ordering" : 1,
+    "identifier" : true
   }, {
     "kind" : "text",
     "name" : "Hauptstadt",

--- a/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
@@ -74,7 +74,7 @@ class SystemController(override val config: TableauxConfig,
       rb <- writeDemoData(readDemoData("regierungsbezirke"))
 
       // Add link column Bundeslaender(Land) <> Regierungsbezirke(Regierungsbezirk)
-      linkColumn <- structureModel.columnStruc.createColumn(bl, CreateLinkColumn("Regierungsbezirke", None, LinkConnection(rb.id, 1, 1), Some("Bundesland"), singleDirection = false, identifier = false))
+      linkColumn <- structureModel.columnStruc.createColumn(bl, CreateLinkColumn("Regierungsbezirke", None, rb.id, Some("Bundesland"), singleDirection = false, identifier = false))
 
       toRow1 = generateToJson(1)
       toRow2 = generateToJson(2)

--- a/src/main/scala/com/campudus/tableaux/database/domain/column.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/column.scala
@@ -114,7 +114,7 @@ case class MultiDateTimeColumn(table: Table, id: ColumnId, name: String, orderin
 /*
  * Special column types
  */
-// TODO What is linkInformation? Could be refactored into case class?
+// TODO What is linkInformation? Could be refactored into case class? Yes it can -> LeftToRight / RightToLeft case objects
 case class LinkColumn[A](table: Table, id: ColumnId, to: ValueColumn[A], linkInformation: (Long, String, String), name: String, ordering: Ordering, override val identifier: Boolean) extends ColumnType[Link[A]] {
   override val kind = LinkType
   override val multilanguage = to.multilanguage

--- a/src/main/scala/com/campudus/tableaux/database/domain/createcolumn.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/createcolumn.scala
@@ -19,7 +19,7 @@ case class CreateSimpleColumn(override val name: String,
 
 case class CreateLinkColumn(override val name: String,
                             override val ordering: Option[Ordering],
-                            linkConnection: LinkConnection,
+                            toTable: TableId,
                             toName: Option[String],
                             singleDirection: Boolean,
                             override val identifier: Boolean) extends CreateColumn {

--- a/src/main/scala/com/campudus/tableaux/database/domain/link.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/link.scala
@@ -3,8 +3,6 @@ package com.campudus.tableaux.database.domain
 import com.campudus.tableaux.database.model.TableauxModel._
 import org.vertx.scala.core.json._
 
-case class LinkConnection(toTableId: TableId, toColumnId: ColumnId, fromColumnId: ColumnId)
-
 case class Link[A](id: RowId, value: A) extends DomainObject {
   override def getJson: JsonObject = Json.obj("id" -> id, "value" -> value)
 }

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -117,7 +117,8 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
     setupVersion2(_),
     setupVersion3(_),
     setupVersion4(_),
-    setupVersion5(_)
+    setupVersion5(_),
+    setupVersion6(_)
   )
 
   private def saveVersion(t: connection.Transaction, version: Int): Future[connection.Transaction] = {
@@ -325,6 +326,23 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
            |""".stripMargin)
 
       t <- saveVersion(t, 5)
+    } yield t
+  }
+
+  private def setupVersion6(t: connection.Transaction): Future[connection.Transaction] = {
+    logger.info("Setup schema version 6")
+
+    for {
+      (t, _) <- t.query(
+        """
+          |ALTER TABLE system_link_table
+          |DROP COLUMN column_id_1,
+          |DROP COLUMN column_id_2,
+          |ADD FOREIGN KEY (table_id_1) REFERENCES system_table(table_id) ON DELETE CASCADE,
+          |ADD FOREIGN KEY (table_id_2) REFERENCES system_table(table_id) ON DELETE CASCADE
+          |""".stripMargin)
+
+      t <- saveVersion(t, 6)
     } yield t
   }
 }

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -299,77 +299,66 @@ class TableauxModel(override protected[this] val connection: DatabaseConnection)
     } yield Row(table, duplicatedRow._1, duplicatedRow._2)
   }
 
-  private def updateValuesInRow(table: Table, rowId: RowId, columnsAndValues: Seq[(ColumnType[_], Any)]): Future[_] = {
-    val insertedCells = for {
-      (column, value) <- columnsAndValues
-    } yield {
-      column match {
-        case link: LinkColumn[_] =>
-          import scala.collection.JavaConverters._
-          val toIds = value.asInstanceOf[JsonArray].asScala.map(_.asInstanceOf[JsonObject].getNumber("id").longValue()).toSeq
-          cellModel.putLinks(table, link, rowId, toIds)
-        case _ =>
-          logger.info(s"value=$value")
-          insertValue(column, rowId, value)
-      }
+  private def mapRawRows(table: Table, columns: Seq[ColumnType[_]], rawRows: Seq[(RowId, Seq[AnyRef])]): Future[Seq[Row]] = {
+
+    def mapNullValueForLinkToConcat(concatColumn: ConcatColumn, array: JsonArray): Future[List[Any]] = {
+      import scala.collection.JavaConversions._
+
+      // Iterate over each linked row and
+      // replace json's value with ConcatColumn value
+      Future.sequence(array.toList.map({
+        case obj: JsonObject =>
+          // ConcatColumn's value is always a
+          // json array with the linked row ids
+          val rowId = obj.getLong("id").longValue()
+          retrieveCell(concatColumn, rowId).map(cell => Json.obj("id" -> rowId, "value" -> cell.value))
+      }))
     }
 
-    Future.sequence(insertedCells)
-  }
-
-  private def mapRawRows(table: Table, columns: Seq[ColumnType[_]], rawRows: Seq[(RowId, Seq[AnyRef])]): Future[Seq[Row]] = {
     // TODO potential performance problem: foreach row every attachment column is mapped and attachments will be fetched!
     val mergedRows = rawRows map {
       case (rowId, rawValues) =>
 
-        logger.info(s"mapping raw row ${table.id} ${columns.map(c => s"${c.id}:${c.kind}")} $rowId -> $rawValues")
         val mergedValues = Future.sequence((columns, rawValues).zipped map {
           case (c: ConcatColumn, value) if c.columns.exists(col => col.kind == LinkType && col.asInstanceOf[LinkColumn[_]].to.isInstanceOf[ConcatColumn]) =>
-
-            logger.info(s"###### ${c.name} - $value - ${value.getClass}")
-
             import scala.collection.JavaConversions._
             import scala.collection.JavaConverters._
+
+            // Because of the guard we only handle ConcatColumns
+            // with LinkColumns to another ConcatColumns
+
+            // Zip concatenated columns with there values
+            val concats = c.columns
+            // value is a Java List because of RowModel.mapResultRow
             val values = value.asInstanceOf[java.util.List[Object]].toList
 
-            val futures = c.columns.zip(values) map {
-              case (column: LinkColumn[_], v: JsonArray) =>
-                column.to match {
-                  case c: ConcatColumn => {
-                    logger.info("////// concat with a link to a concat ")
-                    val t = Future.sequence(v.toList.map({
-                      case linkedObj: JsonObject =>
-                        // value of linkedObj is null in this case, we need to dig further
-                        retrieveCell(column, linkedObj.getLong("id")).map(cell => Json.obj("id"-> linkedObj.getLong("id"), "value"->cell.value))
-                    }))
-                    t.map(_.asJava)
-                  }
-                  case _ => Future.successful(v)
-                }
+            assert(concats.size == values.size)
+
+            val zippedColumnsValues = concats.zip(values)
+
+            // Now we iterate over the zipped sequence and
+            // check for LinkColumns which point to ConcatColumns
+            val mappedColumnValues = zippedColumnsValues map {
+              case (column: LinkColumn[_], array: JsonArray) if column.to.isInstanceOf[ConcatColumn] =>
+                // Iterate over each linked row and
+                // replace json's value with ConcatColumn value
+                mapNullValueForLinkToConcat(column.to.asInstanceOf[ConcatColumn], array).map(_.asJava)
+
               case (column, v) => Future.successful(v)
             }
 
-            Future.sequence(futures).map(_values => {
-              val values = _values.toList
-              logger.info(s"????????? $values")
-              values.asJava
-            })
+            // We need a Java collection so it
+            // can be serialized to JsonArray by vertx
+            Future.sequence(mappedColumnValues).map(_.asJava)
 
-          case (c: LinkColumn[_], value) if c.to.isInstanceOf[ConcatColumn] =>
-            import scala.collection.JavaConversions._
+          case (c: LinkColumn[_], array: JsonArray) if c.to.isInstanceOf[ConcatColumn] =>
             import scala.collection.JavaConverters._
-
-            // ConcatColumn's value is always a
-            // json array with the linked row ids
-            val array = value.asInstanceOf[JsonArray]
 
             // Iterate over each linked row and
             // replace json's value with ConcatColumn value
-            Future.sequence(array.toList.map({
-              case obj: JsonObject =>
-                val rowId = obj.getLong("id").longValue()
-                retrieveCell(c.to, rowId).map(cell => Json.obj("id" -> rowId, "value" -> cell.value))
-            })).map(_.asJava)
+
+            mapNullValueForLinkToConcat(c.to.asInstanceOf[ConcatColumn], array).map(_.asJava)
+
           case (c: AttachmentColumn, _) => attachmentModel.retrieveAll(c.table.id, c.id, rowId)
           case (_, value) => Future(value)
         })

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
@@ -1,6 +1,6 @@
 package com.campudus.tableaux.database.model.structure
 
-import com.campudus.tableaux.NotFoundInDatabaseException
+import com.campudus.tableaux.{DatabaseException, NotFoundInDatabaseException}
 import com.campudus.tableaux.database._
 import com.campudus.tableaux.database.domain._
 import com.campudus.tableaux.database.model.TableauxModel._
@@ -10,6 +10,8 @@ import org.vertx.scala.core.json._
 import scala.concurrent.Future
 
 class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
+
+  lazy val tableStruc = new TableModel(connection)
 
   def createColumns(table: Table, createColumns: Seq[CreateColumn]): Future[Seq[ColumnType[_]]] = {
     createColumns.foldLeft(Future.successful(Seq.empty[ColumnType[_]])) {
@@ -30,9 +32,9 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
           case (id, ordering) => Mapper(languageType, kind).apply(table, id, name, ordering, identifier)
         }
 
-      case CreateLinkColumn(name, ordering, linkConnection, toName, singleDirection, identifier) => for {
-        toCol <- retrieve(linkConnection.toTableId, linkConnection.toColumnId).asInstanceOf[Future[ValueColumn[_]]]
-        (linkId, id, ordering) <- createLinkColumn(table, name, toName, linkConnection, ordering, singleDirection, identifier)
+      case CreateLinkColumn(name, ordering, toTableId, toName, singleDirection, identifier) => for {
+        toCol <- retrieveAll(toTableId).map(_.head.asInstanceOf[ValueColumn[_]])
+        (linkId, id, ordering) <- createLinkColumn(table, name, toName, toTableId, ordering, singleDirection, identifier)
       } yield LinkColumn(table, id, toCol, (linkId, "id_1", "id_2"), name, ordering, identifier)
 
       case CreateAttachmentColumn(name, ordering, identifier) =>
@@ -67,15 +69,12 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
     }
   }
 
-  private def createLinkColumn(table: Table, name: String, toName: Option[String], link: LinkConnection, ordering: Option[Ordering], singleDirection: Boolean, identifier: Boolean): Future[(Long, ColumnId, Ordering)] = {
+  private def createLinkColumn(table: Table, name: String, toName: Option[String], toTableId: TableId, ordering: Option[Ordering], singleDirection: Boolean, identifier: Boolean): Future[(Long, ColumnId, Ordering)] = {
     val tableId = table.id
-    val fromColumnId = link.fromColumnId
-    val toTableId = link.toTableId
-    val toColumnId = link.toColumnId
 
     connection.transactional { t =>
       for {
-        (t, result) <- t.query("INSERT INTO system_link_table (table_id_1, table_id_2, column_id_1, column_id_2) VALUES (?, ?, ?, ?) RETURNING link_id", Json.arr(tableId, toTableId, fromColumnId, toColumnId))
+        (t, result) <- t.query("INSERT INTO system_link_table (table_id_1, table_id_2) VALUES (?, ?) RETURNING link_id", Json.arr(tableId, toTableId))
         linkId = insertNotNull(result).head.get[Long](0)
 
         // insert link column on source table
@@ -134,24 +133,92 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
         // only then the ConcatColumn is generated.
         retrieveAll(tableId).map(_.head)
       case _ =>
-        retrieveOne(tableId, columnId)
+        retrieveOne(tableId, columnId, 5)
     }
   }
 
-  private def retrieveOne(tableId: TableId, columnId: ColumnId): Future[ColumnType[_]] = {
+  private def retrieveOne(tableId: TableId, columnId: ColumnId, depth: Int): Future[ColumnType[_]] = {
     val select = "SELECT column_id, user_column_name, column_type, ordering, multilanguage, identifier FROM system_columns WHERE table_id = ? AND column_id = ?"
     for {
       result <- {
         val json = connection.query(select, Json.arr(tableId, columnId))
         json.map(selectNotNull(_).head)
       }
-      mappedColumn <- mapColumn(mapping = true, tableId, result.get[ColumnId](0), result.get[String](1), Mapper.getDatabaseType(result.get[String](2)), result.get[Ordering](3), LanguageType(result.get[Boolean](4)), result.get[Boolean](5))
+      mappedColumn <- mapColumn(depth, tableId, result.get[ColumnId](0), result.get[String](1), Mapper.getDatabaseType(result.get[String](2)), result.get[Ordering](3), LanguageType(result.get[Boolean](4)), result.get[Boolean](5))
     } yield mappedColumn
   }
 
-  def retrieveAll(tableId: TableId): Future[Seq[ColumnType[_]]] = retrieveAll(tableId, mapping = true)
+//  private def identifierColumn(depth: Int, table: Table, columnId: ColumnId, columnName: String, kind: TableauxDbType,
+//                               ordering: Ordering, languageType: LanguageType): Future[ColumnType[_]] = {
+//
+//    kind match {
+//      case AttachmentType => Future.failed(DatabaseException("Cannot link on attachments. Check schema.", "link-attachment"))
+//      case ConcatType => Future.failed(DatabaseException("Cannot link on concat columns. Check schema.", "link-concat"))
+//      case LinkType => if (depth == 0) {
+//        Future.failed(DatabaseException("Link is too deep. Check schema.", "link-depth"))
+//      } else {
+//        for {
+//          (linkId, id_1, id_2, toTableId, toColumnId) <- getToColumn(table.id, columnId)
+//          linkedTable <- tableStruc.retrieve(toTableId)
+//          linkedIdentifiers <- retrieveIdentifiers(linkedTable, depth - 1)
+//        } yield {
+//          if (linkedIdentifiers.size > 1) {
+//            ConcatColumn(linkedTable, linkedName, linkedIdentifiers)
+//          } else {
+//            linkedIdentifiers.head
+//          }
+//        }
+//      }
+//
+//      case _ => mapValueColumn(table, columnId, columnName, kind, ordering, languageType, identifier = true)
+//    }
+//  }
+//
+//  def retrieveIdentifiers(tableId: TableId): Future[Seq[ColumnType[_]]] = {
+//    for {
+//      table <- tableStruc.retrieve(tableId)
+//      identifiers <- retrieveIdentifiers(table)
+//    } yield identifiers
+//  }
+//
+  private def retrieveIdentifiers(tableId: TableId, depth: Int): Future[Seq[ColumnType[_]]] = {
+    val select = "SELECT column_id, user_column_name, column_type, ordering, multilanguage, identifier FROM system_columns WHERE table_id = ? AND identifier IS TRUE ORDER BY ordering, column_id"
+    for {
+      result <- connection.query(select, Json.arr(tableId))
+      mappedColumns <- {
+        val futures = getSeqOfJsonArray(result).map { arr =>
+          val columnId = arr.get[ColumnId](0)
+          val columnName = arr.get[String](1)
+          val kind = Mapper.getDatabaseType(arr.get[String](2))
+          val ordering = arr.get[Ordering](3)
+          val languageType = LanguageType(arr.get[Boolean](4))
+          val identifier = arr.get[Boolean](5)
 
-  private def retrieveAll(tableId: TableId, mapping: Boolean): Future[Seq[ColumnType[_]]] = {
+          mapColumn(depth, tableId, columnId, columnName, kind, ordering, languageType, identifier)
+        }
+        Future.sequence(futures)
+      }
+    } yield {
+      val concatColumns = mappedColumns.filter(_.identifier)
+
+      concatColumns.size match {
+        case x if x >= 2 =>
+          // in case of two or more identifier columns we preserve the order of column
+          // and a concatcolumn in front of all columns
+          mappedColumns.+:(ConcatColumn(Table(tableId, "", hidden = false), "ID", concatColumns))
+        case x if x == 1 =>
+          // in case of one identifier column we don't get a concat column
+          // but the identifier column will be the first
+          mappedColumns.sortBy(_.identifier)(Ordering[Boolean].reverse)
+        case _ =>
+          throw DatabaseException("Link can not point to table without identifier(s).", "missing-identifier")
+      }
+    }
+  }
+
+  def retrieveAll(tableId: TableId): Future[Seq[ColumnType[_]]] = retrieveAll(tableId, 5)
+
+  private def retrieveAll(tableId: TableId, depth: Int): Future[Seq[ColumnType[_]]] = {
     val select = "SELECT column_id, user_column_name, column_type, ordering, multilanguage, identifier FROM system_columns WHERE table_id = ? ORDER BY ordering, column_id"
     for {
       result <- connection.query(select, Json.arr(tableId))
@@ -164,12 +231,14 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
           val languageType = LanguageType(arr.get[Boolean](4))
           val identifier = arr.get[Boolean](5)
 
-          mapColumn(mapping, tableId, columnId, columnName, kind, ordering, languageType, identifier)
+          mapColumn(depth, tableId, columnId, columnName, kind, ordering, languageType, identifier)
         }
         Future.sequence(futures)
       }
     } yield {
-      val concatColumns = mappedColumns.filter({_.identifier})
+      val concatColumns = mappedColumns.filter({
+        _.identifier
+      })
 
       concatColumns.size match {
         case x if x >= 2 =>
@@ -186,12 +255,12 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
     }
   }
 
-  private def mapColumn(mapping: Boolean, tableId: TableId, columnId: ColumnId, columnName: String, kind: TableauxDbType, ordering: Ordering, languageType: LanguageType, identifier: Boolean): Future[ColumnType[_]] = {
+  private def mapColumn(depth: Int, tableId: TableId, columnId: ColumnId, columnName: String, kind: TableauxDbType, ordering: Ordering, languageType: LanguageType, identifier: Boolean): Future[ColumnType[_]] = {
     val table = Table(tableId, "", hidden = false)
 
     kind match {
       case AttachmentType => mapAttachmentColumn(table, columnId, columnName, ordering, identifier)
-      case LinkType => mapLinkColumn(mapping, table, columnId, columnName, ordering, identifier)
+      case LinkType => mapLinkColumn(depth, table, columnId, columnName, ordering, identifier)
 
       case kind: TableauxDbType => mapValueColumn(table, columnId, columnName, kind, ordering, languageType, identifier)
     }
@@ -205,33 +274,25 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
     Future(AttachmentColumn(table, columnId, columnName, ordering, identifier))
   }
 
-  private def mapLinkColumn(mapping: Boolean, fromTable: Table, linkColumnId: ColumnId, columnName: String, ordering: Ordering, identifier: Boolean): Future[LinkColumn[_]] = {
+  private def mapLinkColumn(depth: Int, fromTable: Table, linkColumnId: ColumnId, columnName: String, ordering: Ordering, identifier: Boolean): Future[LinkColumn[_]] = {
     for {
-      (linkId, id_1, id_2, toTableId, toColumnId) <- getToColumn(fromTable.id, linkColumnId)
+      (linkId, id_1, id_2, toTableId) <- getLinkInformation(fromTable.id, linkColumnId)
 
       foreignColumns <- {
-        if (mapping) {
-          retrieveAll(toTableId, mapping = false)
+        if (depth > 0) {
+          retrieveIdentifiers(toTableId, depth - 1)
         } else {
-          retrieveOne(toTableId, toColumnId).map(Seq(_))
+          Future.failed(DatabaseException("Link is too deep. Check schema.", "link-depth"))
         }
       }
 
       // Link should point at ConcatColumn if defined
-      // Otherwise the first could be an identifier
-      // If nothing is defined we fallback to old habits
-      toColumnOpt = foreignColumns.head match {
-        case c: ConcatColumn =>
-          Some(c)
-        case c: ValueColumn[_] if c.identifier =>
-          Some(c)
-        case _ =>
-          foreignColumns.find(_.id == toColumnId)
-      }
+      // Otherwise use the first column which should be an identifier
+      // If no identifier is defined, use the first column. Period.
+      toColumnOpt = foreignColumns.headOption
     } yield {
-      // TODO Correct error handling? Due to database constraints, this should never happen?
       if (toColumnOpt.isEmpty) {
-        throw new NotFoundInDatabaseException(s"Link points at column $toColumnId in table $toTableId which wasn't found", "not_found")
+        throw new NotFoundInDatabaseException(s"Link points at table $toTableId without columns", "not_found")
       }
 
       val toColumn = toColumnOpt.get.asInstanceOf[ValueColumn[_]]
@@ -239,15 +300,13 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
     }
   }
 
-  private def getToColumn(tableId: TableId, columnId: ColumnId): Future[(Long, String, String, TableId, ColumnId)] = {
+  private def getLinkInformation(tableId: TableId, columnId: ColumnId): Future[(Long, String, String, TableId)] = {
     for {
       result <- connection.query(
         """
           |SELECT
           | table_id_1,
           | table_id_2,
-          | column_id_1,
-          | column_id_2,
           | link_id
           |FROM system_link_table
           |WHERE link_id = (
@@ -256,23 +315,24 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
           |    WHERE table_id = ? AND column_id = ?
           |)""".stripMargin, Json.arr(tableId, columnId))
 
-      (linkId, id_1, id_2, toTableId, toColumnId) <- Future.successful {
+      (linkId, id_1, id_2, toTableId) <- Future.successful {
         val res = selectNotNull(result).head
 
-        val linkId = res.get[Long](4)
+        val linkId = res.getLong(2).toLong
         val table1 = res.get[TableId](0)
 
         /* we need this because links can go both ways */
         if (tableId == table1) {
-          (linkId, "id_1", "id_2", res.get[TableId](1), res.get[ColumnId](3))
+          (linkId, "id_1", "id_2", res.get[TableId](1))
         } else {
-          (linkId, "id_2", "id_1", res.get[TableId](0), res.get[ColumnId](2))
+          (linkId, "id_2", "id_1", res.get[TableId](0))
         }
-      }
-    } yield (linkId, id_1, id_2, toTableId, toColumnId)
+      } // TODO create a unfunny case object for this
+    } yield (linkId, id_1, id_2, toTableId)
   }
 
   def delete(tableId: TableId, columnId: ColumnId): Future[Unit] = {
+    // TODO if last column than throw an error
     for {
       column <- retrieve(tableId, columnId)
       _ <- {

--- a/src/test/scala/com/campudus/tableaux/CreationTest.scala
+++ b/src/test/scala/com/campudus/tableaux/CreationTest.scala
@@ -176,7 +176,7 @@ class CreationTest extends TableauxTestBase {
 
   @Test
   def createComplexRow(implicit c: TestContext): Unit = okTest {
-    val postLinkCol = Json.obj("columns" -> Json.arr(Json.obj("name" -> "Test Link 1", "kind" -> "link", "fromColumn" -> 1, "toTable" -> 2, "toColumn" -> 1)))
+    val postLinkCol = Json.obj("columns" -> Json.arr(Json.obj("name" -> "Test Link 1", "kind" -> "link", "toTable" -> 2)))
     val postAttachmentColumn = Json.obj("columns" -> Json.arr(Json.obj(
       "kind" -> "attachment",
       "name" -> "Downloads"
@@ -271,7 +271,7 @@ class CreationTest extends TableauxTestBase {
 
   @Test
   def duplicateRowWithLink(implicit c: TestContext): Unit = okTest {
-    val postLinkCol = Json.obj("columns" -> Json.arr(Json.obj("name" -> "Test Link 1", "kind" -> "link", "fromColumn" -> 1, "toTable" -> 2, "toColumn" -> 1)))
+    val postLinkCol = Json.obj("columns" -> Json.arr(Json.obj("name" -> "Test Link 1", "kind" -> "link", "toTable" -> 2)))
     def fillLinkCellJson(c: Integer) = Json.obj("value" -> Json.obj("to" -> c))
 
     for {

--- a/src/test/scala/com/campudus/tableaux/DeleteTest.scala
+++ b/src/test/scala/com/campudus/tableaux/DeleteTest.scala
@@ -64,9 +64,7 @@ class DeleteTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
-          "toTable" -> 2,
-          "toColumn" -> 1
+          "toTable" -> 2
         )
       )
     )
@@ -83,6 +81,7 @@ class DeleteTest extends TableauxTestBase {
       test <- sendRequest("DELETE", "/tables/1")
     } yield {
       assertEquals(expectedOkJson, test)
+      // TODO check 404 at GET /tables/1 and check link is gone in /tables/2
     }
   }
 
@@ -93,9 +92,7 @@ class DeleteTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
-          "toTable" -> 2,
-          "toColumn" -> 1
+          "toTable" -> 2
         )
       )
     )
@@ -112,6 +109,7 @@ class DeleteTest extends TableauxTestBase {
       test <- sendRequest("DELETE", "/tables/1/columns/2")
     } yield {
       assertEquals(expectedOkJson, test)
+      // TODO check GET /tables/1/columns/2 for 404 and GET /tables/2/columns/2 is still there (bidirectional link)
     }
   }
 

--- a/src/test/scala/com/campudus/tableaux/DeleteTest.scala
+++ b/src/test/scala/com/campudus/tableaux/DeleteTest.scala
@@ -11,6 +11,7 @@ class DeleteTest extends TableauxTestBase {
 
   val createTableJson = Json.obj("name" -> "Test Nr. 1")
   val createStringColumnJson = Json.obj("columns" -> Json.arr(Json.obj("kind" -> "text", "name" -> "Test Column 1")))
+  val createIdentifierStringColumnJson = Json.obj("columns" -> Json.arr(Json.obj("kind" -> "text", "name" -> "Test Column 1", "identifier" -> true)))
 
   val expectedOkJson = Json.obj("status" -> "ok")
 
@@ -73,8 +74,8 @@ class DeleteTest extends TableauxTestBase {
       table1 <- sendRequest("POST", "/tables", createTableJson).map(_.getLong("id"))
       table2 <- sendRequest("POST", "/tables", createTableJson).map(_.getLong("id"))
 
-      _ <- sendRequest("POST", s"/tables/$table1/columns", createStringColumnJson)
-      _ <- sendRequest("POST", s"/tables/$table2/columns", createStringColumnJson)
+      _ <- sendRequest("POST", s"/tables/$table1/columns", createIdentifierStringColumnJson)
+      _ <- sendRequest("POST", s"/tables/$table2/columns", createIdentifierStringColumnJson)
 
       _ <- sendRequest("POST", s"/tables/$table1/columns", createLinkColumnJson)
 
@@ -101,8 +102,8 @@ class DeleteTest extends TableauxTestBase {
       table1 <- sendRequest("POST", "/tables", createTableJson).map(_.getLong("id"))
       table2 <- sendRequest("POST", "/tables", createTableJson).map(_.getLong("id"))
 
-      _ <- sendRequest("POST", s"/tables/$table1/columns", createStringColumnJson)
-      _ <- sendRequest("POST", s"/tables/$table2/columns", createStringColumnJson)
+      _ <- sendRequest("POST", s"/tables/$table1/columns", createIdentifierStringColumnJson)
+      _ <- sendRequest("POST", s"/tables/$table2/columns", createIdentifierStringColumnJson)
 
       _ <- sendRequest("POST", s"/tables/$table1/columns", createLinkColumnJson)
 

--- a/src/test/scala/com/campudus/tableaux/ErrorTest.scala
+++ b/src/test/scala/com/campudus/tableaux/ErrorTest.scala
@@ -151,15 +151,7 @@ class ErrorTest extends TableauxTestBase {
 
   @Test
   def createMultipleLinkColumnsWithoutToTable(implicit c: TestContext): Unit = multipleColumnHelper(errorJsonNull, Json.obj("columns" -> Json.arr(
-    Json.obj("kind" -> "link", "name" -> "Test Column 1", "toColumn" -> 1, "fromColumn" -> 1))))
-
-  @Test
-  def createMultipleLinkColumnsWithoutToColumn(implicit c: TestContext): Unit = multipleColumnHelper(errorJsonNull, Json.obj("columns" -> Json.arr(
-    Json.obj("kind" -> "link", "name" -> "Test Column 1", "toTable" -> 1, "fromColumn" -> 1))))
-
-  @Test
-  def createMultipleLinkColumnsWithoutFromColumn(implicit c: TestContext): Unit = multipleColumnHelper(errorJsonNull, Json.obj("columns" -> Json.arr(
-    Json.obj("kind" -> "link", "name" -> "Test Column 1", "toTable" -> 1, "toColumn" -> 1))))
+    Json.obj("kind" -> "link", "name" -> "Test Column 1"))))
 
   private def multipleColumnHelper(error: String, json: JsonObject)(implicit c: TestContext): Unit = exceptionTest(error) {
     for {

--- a/src/test/scala/com/campudus/tableaux/GetTest.scala
+++ b/src/test/scala/com/campudus/tableaux/GetTest.scala
@@ -180,7 +180,7 @@ class GetTest extends TableauxTestBase {
   @Test
   def retrieveColumns(implicit c: TestContext): Unit = okTest {
     val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(
-      Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> false),
+      Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> true),
       Json.obj("id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2, "multilanguage" -> false, "identifier" -> false)
     ))
 
@@ -194,7 +194,7 @@ class GetTest extends TableauxTestBase {
 
   @Test
   def retrieveStringColumn(implicit c: TestContext): Unit = okTest {
-    val expectedJson = Json.obj("status" -> "ok", "id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> false)
+    val expectedJson = Json.obj("status" -> "ok", "id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> true)
 
     for {
       _ <- setupDefaultTable()

--- a/src/test/scala/com/campudus/tableaux/IdentifierTest.scala
+++ b/src/test/scala/com/campudus/tableaux/IdentifierTest.scala
@@ -61,15 +61,87 @@ class IdentifierTest extends TableauxTestBase {
     ???
   }
 
-  @Ignore("not implemented - retrieve links on links on links ... that use concat columns")
   @Test
   def retrieveLinksOnConcatColumnsRecursively(implicit c: TestContext): Unit = okTest {
-    // TODO Add test
-    // create multiple tables that link on concat columns
-    // verify that each concat has the needed column information
-    // verify that the values are of the provided type
-    // verify that the values are fetched recursively
-    ???
+    def putLink(id: Long) = Json.obj("value" -> Json.obj("values" -> Json.arr(id)))
+    def putLinks(ids: Seq[Long]) = Json.obj("value" -> Json.obj("values" -> Json.arr(ids: _*)))
+    for {
+
+    // create multiple tables
+      (tableId1, columnIds1, rowIds1) <- createSimpleTableWithValues("table1", List(Text("text11"), Identifier(Numeric("num12")), Identifier(Multilanguage(Text("multitext13"))), Numeric("num14")), List(
+        List("table1col1row1", 121, Json.obj("de_DE" -> "table1col3row1-de", "en_GB" -> "table1col3row1-gb"), 141),
+        List("table1col1row2", 122, Json.obj("de_DE" -> "table1col3row2-de", "en_GB" -> "table1col3row2-gb"), 142)
+      ))
+      (tableId2, columnIds2, rowIds2) <- createSimpleTableWithValues("table2", List(Text("text21"), Identifier(Numeric("num22")), Identifier(Multilanguage(Text("multitext23"))), Numeric("num24")), List(
+        List("table2col1row1", 221, Json.obj("de_DE" -> "table2col3row1-de", "en_GB" -> "table2col3row1-gb"), 241),
+        List("table2col1row2", 222, Json.obj("de_DE" -> "table2col3row2-de", "en_GB" -> "table2col3row2-gb"), 242)
+      ))
+      (tableId3, columnIds3, rowIds3) <- createSimpleTableWithValues("table3", List(Text("text31"), Identifier(Numeric("num32")), Identifier(Multilanguage(Text("multitext33"))), Numeric("num34")), List(
+        List("table3col1row1", 321, Json.obj("de_DE" -> "table3col3row1-de", "en_GB" -> "table3col3row1-gb"), 341),
+        List("table3col1row2", 322, Json.obj("de_DE" -> "table3col3row2-de", "en_GB" -> "table3col3row2-gb"), 342)
+      ))
+      (tableId4, columnIds4, rowIds4) <- createSimpleTableWithValues("table4", List(Text("text41"), Identifier(Numeric("num42")), Identifier(Multilanguage(Text("multitext43"))), Numeric("num44")), List(
+        List("table4col1row1", 421, Json.obj("de_DE" -> "table4col3row1-de", "en_GB" -> "table4col3row1-gb"), 441),
+        List("table4col1row2", 422, Json.obj("de_DE" -> "table4col3row2-de", "en_GB" -> "table4col3row2-gb"), 442)
+      ))
+
+      // ... that link on concat columns
+      postLinkColTable2 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link251", "kind" -> "link", "fromColumn" -> 1, "toTable" -> tableId1, "toColumn" -> 1, "identifier" -> true)))
+      linkColRes2 <- sendRequest("POST", s"/tables/$tableId2/columns", postLinkColTable2)
+      linkColId2 = linkColRes2.getJsonArray("columns").getJsonObject(0).getLong("id")
+      postLinkColTable3 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link352", "kind" -> "link", "fromColumn" -> 1, "toTable" -> tableId2, "toColumn" -> 1, "identifier" -> true)))
+      linkColRes3 <- sendRequest("POST", s"/tables/$tableId3/columns", postLinkColTable3)
+      linkColId3 = linkColRes3.getJsonArray("columns").getJsonObject(0).getLong("id")
+      postLinkColTable4 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link452", "kind" -> "link", "fromColumn" -> 1, "toTable" -> tableId3, "toColumn" -> 1)))
+      linkColRes4 <- sendRequest("POST", s"/tables/$tableId4/columns", postLinkColTable4)
+      linkColId4 = linkColRes4.getJsonArray("columns").getJsonObject(0).getLong("id")
+
+      // verify that each concat has the needed column information
+      // verify that the values are of the provided type
+      // verify that the values are fetched recursively
+
+      // add link from table2row1 to table1row1 and to table1row2
+      _ <- sendRequest("POST", s"/tables/$tableId2/columns/$linkColId2/rows/${rowIds2.head}", putLinks(rowIds1))
+
+      // add link from table2row2 to table1row1
+      _ <- sendRequest("POST", s"/tables/$tableId2/columns/$linkColId2/rows/${rowIds2(1)}", putLink(rowIds1.head))
+
+      // add link from table3row1 to table2row1 and to table2row2
+      _ <- sendRequest("POST", s"/tables/$tableId3/columns/$linkColId3/rows/${rowIds3.head}", putLinks(rowIds2))
+
+      // add link from table4row1 to table3row1
+      _ <- sendRequest("POST", s"/tables/$tableId4/columns/$linkColId4/rows/${rowIds4.head}", putLink(rowIds3.head))
+
+      columnResult <- sendRequest("GET", s"/tables/$tableId4/columns/$linkColId4")
+      cellResult <- sendRequest("GET", s"/tables/$tableId4/columns/$linkColId4/rows/${rowIds4.head}")
+    } yield {
+      logger.info(s"columnResult=${columnResult.encode()}")
+      logger.info(s"cellResult=${cellResult.encode()}")
+
+      val toColumn = columnResult.getJsonObject("toColumn")
+      assertEquals("concat", toColumn.getString("kind"))
+      val concats = toColumn.getJsonArray("concats")
+      assertEquals(3, concats.size)
+
+      val concats1 = concats.getJsonObject(0)
+      val concats2 = concats.getJsonObject(1)
+      val concats3 = concats.getJsonObject(2)
+      assertEquals(columnIds3(1), concats1.getLong("id"))
+      assertEquals("numeric", concats1.getString("kind"))
+      assertEquals(columnIds3(2), concats2.getLong("id"))
+      assertEquals("text", concats2.getString("kind"))
+      assertEquals(true, concats2.getBoolean("multilanguage"))
+      assertEquals(linkColId3, concats3.getLong("id"))
+      assertEquals("link", concats3.getString("kind"))
+
+      assertEquals(tableId2, concats3.getLong("toTable"))
+      val toTable2 = concats3.getJsonObject("toColumn")
+      assertEquals(0, toTable2.getLong("id"))
+      assertEquals("concat", toTable2.getLong("kind"))
+      val concatsTo2 = toTable2.getJsonArray("concats")
+      assertEquals(3, concatsTo2.size())
+
+    }
   }
 
   @Test
@@ -85,7 +157,7 @@ class IdentifierTest extends TableauxTestBase {
         List("table2col1row1", 221, Json.obj("de_DE" -> "table2col3row1-de", "en_GB" -> "table2col3row1-gb"), 241),
         List("table2col1row2", 222, Json.obj("de_DE" -> "table2col3row2-de", "en_GB" -> "table2col3row2-gb"), 242)
       ))
-      (tableId3, columnIds3, rowIds3) <- createSimpleTableWithValues("table2", List(Text("text31"), Identifier(Numeric("num32")), Identifier(Multilanguage(Text("multitext23"))), Numeric("num34")), List(
+      (tableId3, columnIds3, rowIds3) <- createSimpleTableWithValues("table3", List(Text("text31"), Identifier(Numeric("num32")), Identifier(Multilanguage(Text("multitext33"))), Numeric("num34")), List(
         List("table3col1row1", 321, Json.obj("de_DE" -> "table3col3row1-de", "en_GB" -> "table3col3row1-gb"), 341),
         List("table3col1row2", 322, Json.obj("de_DE" -> "table3col3row2-de", "en_GB" -> "table3col3row2-gb"), 342)
       ))

--- a/src/test/scala/com/campudus/tableaux/IdentifierTest.scala
+++ b/src/test/scala/com/campudus/tableaux/IdentifierTest.scala
@@ -86,13 +86,13 @@ class IdentifierTest extends TableauxTestBase {
       ))
 
       // ... that link on concat columns
-      postLinkColTable2 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link251", "kind" -> "link", "fromColumn" -> 1, "toTable" -> tableId1, "toColumn" -> 1, "identifier" -> true)))
+      postLinkColTable2 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link251", "kind" -> "link", "toTable" -> tableId1, "identifier" -> true)))
       linkColRes2 <- sendRequest("POST", s"/tables/$tableId2/columns", postLinkColTable2)
       linkColId2 = linkColRes2.getJsonArray("columns").getJsonObject(0).getLong("id")
-      postLinkColTable3 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link352", "kind" -> "link", "fromColumn" -> 1, "toTable" -> tableId2, "toColumn" -> 1, "identifier" -> true)))
+      postLinkColTable3 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link352", "kind" -> "link", "toTable" -> tableId2, "identifier" -> true)))
       linkColRes3 <- sendRequest("POST", s"/tables/$tableId3/columns", postLinkColTable3)
       linkColId3 = linkColRes3.getJsonArray("columns").getJsonObject(0).getLong("id")
-      postLinkColTable4 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link452", "kind" -> "link", "fromColumn" -> 1, "toTable" -> tableId3, "toColumn" -> 1)))
+      postLinkColTable4 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link452", "kind" -> "link", "toTable" -> tableId3)))
       linkColRes4 <- sendRequest("POST", s"/tables/$tableId4/columns", postLinkColTable4)
       linkColId4 = linkColRes4.getJsonArray("columns").getJsonObject(0).getLong("id")
 
@@ -163,10 +163,10 @@ class IdentifierTest extends TableauxTestBase {
       ))
 
       // add link column from table 1 to table 2 and make it identifier
-      postLinkColTable2 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link251", "kind" -> "link", "fromColumn" -> 1, "toTable" -> tableId1, "toColumn" -> 1, "identifier" -> true)))
+      postLinkColTable2 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link251", "kind" -> "link", "toTable" -> tableId1, "identifier" -> true)))
       linkColRes2 <- sendRequest("POST", s"/tables/$tableId2/columns", postLinkColTable2)
       linkColId2 = linkColRes2.getJsonArray("columns").getJsonObject(0).getLong("id")
-      postLinkColTable3 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link352", "kind" -> "link", "fromColumn" -> 1, "toTable" -> tableId2, "toColumn" -> 1)))
+      postLinkColTable3 = Json.obj("columns" -> Json.arr(Json.obj("name" -> "link352", "kind" -> "link", "toTable" -> tableId2)))
       linkColRes3 <- sendRequest("POST", s"/tables/$tableId3/columns", postLinkColTable3)
       linkColId3 = linkColRes3.getJsonArray("columns").getJsonObject(0).getLong("id")
 
@@ -231,9 +231,7 @@ class IdentifierTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
-          "toTable" -> 2,
-          "toColumn" -> 2
+          "toTable" -> 2
         )
       )
     )
@@ -278,9 +276,7 @@ class IdentifierTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
-          "toTable" -> 2,
-          "toColumn" -> 3
+          "toTable" -> 2
         )
       )
     )
@@ -290,9 +286,7 @@ class IdentifierTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
-          "toTable" -> 3,
-          "toColumn" -> 1
+          "toTable" -> 3
         )
       )
     )

--- a/src/test/scala/com/campudus/tableaux/LinkTest.scala
+++ b/src/test/scala/com/campudus/tableaux/LinkTest.scala
@@ -29,7 +29,7 @@ class LinkTest extends TableauxTestBase {
         "name" -> "Test Column 1",
         "kind" -> "text",
         "multilanguage" -> false,
-        "identifier" -> false
+        "identifier" -> true
       ),
       "ordering" -> 3,
       "identifier" -> false
@@ -199,7 +199,7 @@ class LinkTest extends TableauxTestBase {
 
       // create link column
       res <- sendRequest("POST", "/tables/1/columns", linkColumn)
-      linkColumnId <- Future.apply(res.getArray("columns").get[JsonObject](0).getNumber("id"))
+      linkColumnId = res.getArray("columns").get[JsonObject](0).getNumber("id")
 
       // add rows to tables
       table1RowId1 <- addRow(1, valuesRow("table1RowId1"))
@@ -228,7 +228,7 @@ class LinkTest extends TableauxTestBase {
           "table1RowId1",
           2,
           Json.arr(
-            Json.obj("id" -> table2RowId2, "value" -> 2)
+            Json.obj("id" -> table2RowId2, "value" -> "table2RowId2")
           )
         )
       )
@@ -358,8 +358,8 @@ class LinkTest extends TableauxTestBase {
       resGet4 <- sendRequest("GET", s"/tables/$tableId2/columns/$linkColumnId/rows/2")
     } yield {
       val expected1 = Json.obj("status" -> "ok", "value" -> Json.arr(
-        Json.obj("id" -> 1, "value" -> Json.obj("en_US" -> "Hello, Table 2 Col 1 Row 1!")),
-        Json.obj("id" -> 2, "value" -> Json.obj("en_US" -> "Hello, Table 2 Col 1 Row 2!"))
+        Json.obj("id" -> 1, "value" -> Json.obj("en_US" -> "Hello, Table 2 World!", "de_DE" -> "Hallo, Table 2 Welt!")),
+        Json.obj("id" -> 2, "value" -> Json.obj("en_US" -> "Hello, Table 2 World2!", "de_DE" -> "Hallo, Table 2 Welt2!"))
       ))
       val expected2 = Json.obj("status" -> "ok", "value" -> Json.arr())
       val expected3 = Json.obj("status" -> "ok", "value" ->
@@ -408,8 +408,8 @@ class LinkTest extends TableauxTestBase {
       resGet4 <- sendRequest("GET", s"/tables/$tableId2/columns/$linkColumnId/rows/${table2rowIds.drop(1).head}")
     } yield {
       val expected1 = Json.obj("status" -> "ok", "value" -> Json.arr(
-        Json.obj("id" -> 1, "value" -> Json.obj("en_US" -> "Hello, Table 2 Col 1 Row 1!")),
-        Json.obj("id" -> 2, "value" -> Json.obj("en_US" -> "Hello, Table 2 Col 1 Row 2!"))
+        Json.obj("id" -> 1, "value" -> Json.obj("en_US" -> "Hello, Table 2 World!", "de_DE" -> "Hallo, Table 2 Welt!")),
+        Json.obj("id" -> 2, "value" -> Json.obj("en_US" -> "Hello, Table 2 World2!", "de_DE" -> "Hallo, Table 2 Welt2!"))
       ))
       val expected2 = Json.obj("status" -> "ok", "value" -> Json.arr())
       val expected3 = Json.obj("status" -> "ok", "value" ->
@@ -564,7 +564,7 @@ class LinkTest extends TableauxTestBase {
     def putLinks(arr: JsonArray) = Json.obj("value" -> Json.obj("values" -> arr))
 
     val postTable = Json.obj("name" -> "Test Table")
-    val createStringColumnJson = Json.obj("columns" -> Json.arr(Json.obj("kind" -> "text", "name" -> "Test Column 1")))
+    val createStringColumnJson = Json.obj("columns" -> Json.arr(Json.obj("kind" -> "text", "name" -> "Test Column 1", "identifier" -> true)))
 
     for {
       tableId <- sendRequest("POST", "/tables", postTable) map { js => js.getLong("id") }

--- a/src/test/scala/com/campudus/tableaux/LinkTest.scala
+++ b/src/test/scala/com/campudus/tableaux/LinkTest.scala
@@ -11,8 +11,8 @@ import scala.concurrent.Future
 @RunWith(classOf[VertxUnitRunner])
 class LinkTest extends TableauxTestBase {
 
-  val postLinkCol = Json.obj("columns" -> Json.arr(Json.obj("name" -> "Test Link 1", "kind" -> "link", "fromColumn" -> 1, "toTable" -> 2, "toColumn" -> 1)))
-  val postSingleDirectionLinkCol = Json.obj("columns" -> Json.arr(Json.obj("name" -> "Test Link 1", "kind" -> "link", "fromColumn" -> 1, "toTable" -> 2, "toColumn" -> 1, "singleDirection" -> true)))
+  val postLinkCol = Json.obj("columns" -> Json.arr(Json.obj("name" -> "Test Link 1", "kind" -> "link", "toTable" -> 2)))
+  val postSingleDirectionLinkCol = Json.obj("columns" -> Json.arr(Json.obj("name" -> "Test Link 1", "kind" -> "link", "toTable" -> 2, "singleDirection" -> true)))
 
   @Test
   def retrieveLinkColumn(implicit c: TestContext): Unit = okTest {
@@ -58,7 +58,7 @@ class LinkTest extends TableauxTestBase {
 
   @Test
   def createLinkColumnWithOrdering(implicit c: TestContext): Unit = okTest {
-    val postLinkColWithOrd = Json.obj("columns" -> Json.arr(Json.obj("name" -> "Test Link 1", "kind" -> "link", "fromColumn" -> 1, "toTable" -> 2, "toColumn" -> 1, "ordering" -> 5)))
+    val postLinkColWithOrd = Json.obj("columns" -> Json.arr(Json.obj("name" -> "Test Link 1", "kind" -> "link", "toTable" -> 2, "ordering" -> 5)))
     val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 3, "ordering" -> 5)))
 
     for {
@@ -76,10 +76,8 @@ class LinkTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
           "toName" -> "Backlink",
           "toTable" -> 2,
-          "toColumn" -> 1,
           "ordering" -> 5
         )
       )
@@ -184,9 +182,7 @@ class LinkTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
-          "toTable" -> 2,
-          "toColumn" -> 2
+          "toTable" -> 2
         )
       )
     )
@@ -261,9 +257,7 @@ class LinkTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
-          "toTable" -> 2,
-          "toColumn" -> 1
+          "toTable" -> 2
         )
       )
     )
@@ -341,9 +335,7 @@ class LinkTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
-          "toTable" -> 2,
-          "toColumn" -> 4
+          "toTable" -> 2
         )
       )
     )
@@ -393,9 +385,7 @@ class LinkTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
-          "toTable" -> 2,
-          "toColumn" -> 4
+          "toTable" -> 2
         )
       )
     )
@@ -520,9 +510,7 @@ class LinkTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
-          "toTable" -> 2,
-          "toColumn" -> 2
+          "toTable" -> 2
         )
       )
     )
@@ -558,9 +546,7 @@ class LinkTest extends TableauxTestBase {
         Json.obj(
           "name" -> "Test Link 1",
           "kind" -> "link",
-          "fromColumn" -> 1,
-          "toTable" -> 1,
-          "toColumn" -> 1
+          "toTable" -> 1
         )
       )
     )

--- a/src/test/scala/com/campudus/tableaux/MultiLanguageTest.scala
+++ b/src/test/scala/com/campudus/tableaux/MultiLanguageTest.scala
@@ -21,7 +21,7 @@ class MultiLanguageTest extends TableauxTestBase {
       "kind" -> "text",
       "ordering" -> columnId,
       "multilanguage" -> true,
-      "identifier" -> false
+      "identifier" -> true
     )
 
     for {

--- a/src/test/scala/com/campudus/tableaux/TableauxTestBase.scala
+++ b/src/test/scala/com/campudus/tableaux/TableauxTestBase.scala
@@ -395,9 +395,7 @@ trait TableauxTestBase extends TestConfig with LazyLogging with TestAssertionHel
     def createLinkColumn(fromColumnId: Long, linkTo: LinkTo) = Json.obj("columns" -> Json.arr(Json.obj(
       "kind" -> "link",
       "name" -> "column 10 (link)",
-      "fromColumn" -> fromColumnId,
-      "toTable" -> linkTo.tableId,
-      "toColumn" -> linkTo.columnId
+      "toTable" -> linkTo.tableId
     )))
 
     import scala.collection.JavaConverters._

--- a/src/test/scala/com/campudus/tableaux/TableauxTestBase.scala
+++ b/src/test/scala/com/campudus/tableaux/TableauxTestBase.scala
@@ -355,7 +355,7 @@ trait TableauxTestBase extends TestConfig with LazyLogging with TestAssertionHel
     val createMultilanguageColumn = Json.obj(
       "columns" ->
         Json.arr(
-          Json.obj("kind" -> "text", "name" -> "Test Column 1", "multilanguage" -> true),
+          Json.obj("kind" -> "text", "name" -> "Test Column 1", "multilanguage" -> true, "identifier" -> true),
           Json.obj("kind" -> "boolean", "name" -> "Test Column 2", "multilanguage" -> true),
           Json.obj("kind" -> "numeric", "name" -> "Test Column 3", "multilanguage" -> true),
           Json.obj("kind" -> "richtext", "name" -> "Test Column 4", "multilanguage" -> true),

--- a/src/test/scala/com/campudus/tableaux/TableauxTestBase.scala
+++ b/src/test/scala/com/campudus/tableaux/TableauxTestBase.scala
@@ -205,7 +205,7 @@ trait TableauxTestBase extends TestConfig with LazyLogging with TestAssertionHel
 
   def setupDefaultTable(name: String = "Test Table 1", tableNum: Int = 1): Future[Long] = {
     val postTable = Json.obj("name" -> name)
-    val createStringColumnJson = Json.obj("columns" -> Json.arr(Json.obj("kind" -> "text", "name" -> "Test Column 1")))
+    val createStringColumnJson = Json.obj("columns" -> Json.arr(Json.obj("kind" -> "text", "name" -> "Test Column 1", "identifier" -> true)))
     val createNumberColumnJson = Json.obj("columns" -> Json.arr(Json.obj("kind" -> "numeric", "name" -> "Test Column 2")))
     val fillStringCellJson = Json.obj("value" -> s"table${tableNum}row1")
     val fillStringCellJson2 = Json.obj("value" -> s"table${tableNum}row2")

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -64,8 +64,8 @@ class SystemControllerTest extends TableauxTestBase {
       "versions" -> Json.obj(
         "implementation" -> "DEVELOPMENT",
         "database" -> Json.obj(
-          "current" -> 5,
-          "specification" -> 5
+          "current" -> 6,
+          "specification" -> 6
         )
       ),
       "status" -> "ok"


### PR DESCRIPTION
Remove `toColumn` and `fromColumn` from links. Since we're using `identifier` columns now, this will make the code a bit cleaner and easier to add features.

We will only go 5 layers deep into links to search for concat columns. This lets us know when we have some schemas with cycles. We can change this to a real cycle-check and remove this limitation later.