### PR TITLE
Add multilanguage displayName and description to columns

### DIFF
--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -6,6 +6,7 @@ import com.campudus.tableaux.database._
 import com.campudus.tableaux.database.domain._
 import com.campudus.tableaux.database.model.StructureModel
 import com.campudus.tableaux.database.model.TableauxModel._
+import org.vertx.scala.core.json.JsonObject
 
 import scala.concurrent.Future
 
@@ -43,7 +44,6 @@ class StructureController(override val config: TableauxConfig, override protecte
       retrieved <- Future.sequence(created.map(c => retrieveColumn(c.table.id, c.id)))
       sorted = retrieved.sortBy(_.ordering)
     } yield {
-      logger.info(s"$columns")
       ColumnSeq(sorted)
     }
   }
@@ -138,14 +138,13 @@ class StructureController(override val config: TableauxConfig, override protecte
     } yield EmptyObject()
   }
 
-  def changeColumn(tableId: TableId, columnId: ColumnId, columnName: Option[String], ordering: Option[Ordering], kind: Option[TableauxDbType], identifier: Option[Boolean]): Future[ColumnType[_]] = {
+  def changeColumn(tableId: TableId, columnId: ColumnId, columnName: Option[String], ordering: Option[Ordering], kind: Option[TableauxDbType], identifier: Option[Boolean], displayName: Option[JsonObject], description: Option[JsonObject]): Future[ColumnType[_]] = {
     checkArguments(greaterZero(tableId), greaterZero(columnId))
-    logger.info(s"changeColumn $tableId $columnId name=$columnName ordering=$ordering kind=$kind identifier=$identifier")
+    logger.info(s"changeColumn $tableId $columnId name=$columnName ordering=$ordering kind=$kind identifier=$identifier displayName=${displayName.map(_.encode())} description=${description.map(_.encode())}")
 
     for {
       table <- tableStruc.retrieve(tableId)
-      changed <- columnStruc.change(table, columnId, columnName, ordering, kind, identifier)
-      column <- columnStruc.retrieve(changed.table, changed.id)
-    } yield column
+      changed <- columnStruc.change(table, columnId, columnName, ordering, kind, identifier, displayName, description)
+    } yield changed
   }
 }

--- a/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
@@ -87,7 +87,7 @@ class SystemController(override val config: TableauxConfig,
       rb <- writeDemoData(readDemoData("regierungsbezirke"))
 
       // Add link column Bundeslaender(Land) <> Regierungsbezirke(Regierungsbezirk)
-      linkColumn <- structureModel.columnStruc.createColumn(bl, CreateLinkColumn("Regierungsbezirke", None, rb.id, Some("Bundesland"), singleDirection = false, identifier = false))
+      linkColumn <- structureModel.columnStruc.createColumn(bl, CreateLinkColumn("Regierungsbezirke", None, rb.id, Some("Bundesland"), singleDirection = false, identifier = false, List()))
 
       toRow1 = generateToJson(1)
       toRow2 = generateToJson(2)

--- a/src/main/scala/com/campudus/tableaux/database/dbtype.scala
+++ b/src/main/scala/com/campudus/tableaux/database/dbtype.scala
@@ -125,7 +125,7 @@ case object MultiLanguage extends LanguageType {
 }
 
 object Mapper {
-  private def columnType(languageType: LanguageType, kind: TableauxDbType): Option[(Table, ColumnId, String, Ordering, Boolean) => ColumnType[_]] = {
+  private def columnType(languageType: LanguageType, kind: TableauxDbType): Option[(Table, ColumnId, String, Ordering, Boolean, Seq[DisplayInfo]) => ColumnType[_]] = {
     languageType match {
       case SingleLanguage => kind match {
         // primitive/simple types
@@ -157,7 +157,7 @@ object Mapper {
     }
   }
 
-  def apply(languageType: LanguageType, kind: TableauxDbType): (Table, ColumnId, String, Ordering, Boolean) => ColumnType[_] = columnType(languageType, kind).get
+  def apply(languageType: LanguageType, kind: TableauxDbType): (Table, ColumnId, String, Ordering, Boolean, Seq[DisplayInfo]) => ColumnType[_] = columnType(languageType, kind).get
 
   def getDatabaseType(kind: String): TableauxDbType = {
     kind match {

--- a/src/main/scala/com/campudus/tableaux/database/domain/column.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/column.scala
@@ -7,6 +7,7 @@ import com.campudus.tableaux.database.model.TableauxModel._
 import org.joda.time.{DateTime, LocalDate}
 import org.vertx.scala.core.json._
 
+// TODO We should put all infos into a ColumnInfo case class or similar: Every change in a column needs a lot of changes elsewhere
 sealed trait ColumnType[+A] extends DomainObject {
   val kind: TableauxDbType
 
@@ -22,14 +23,25 @@ sealed trait ColumnType[+A] extends DomainObject {
 
   val identifier: Boolean = false
 
-  override def getJson: JsonObject = Json.obj(
-    "id" -> id,
-    "ordering" -> ordering,
-    "name" -> name,
-    "kind" -> kind.toString,
-    "multilanguage" -> multilanguage,
-    "identifier" -> identifier
-  )
+  val displayInfos: Seq[DisplayInfo]
+
+  override def getJson: JsonObject = {
+    val json = Json.obj(
+      "id" -> id,
+      "ordering" -> ordering,
+      "name" -> name,
+      "kind" -> kind.toString,
+      "multilanguage" -> multilanguage,
+      "identifier" -> identifier,
+      "displayName" -> Json.obj(),
+      "description" -> Json.obj()
+    )
+    displayInfos.foreach { di =>
+      di.optionalName.map(name => json.mergeIn(Json.obj("displayName" -> json.getJsonObject("displayName").mergeIn(Json.obj(di.langtag -> name)))))
+      di.optionalDescription.map(desc => json.mergeIn(Json.obj("description" -> json.getJsonObject("description").mergeIn(Json.obj(di.langtag -> desc)))))
+    }
+    json
+  }
 
   def checkValidValue[B](value: B): Option[String] = if (value == null) None else kind.checkValidValue(value)
 }
@@ -44,26 +56,26 @@ sealed trait SimpleValueColumn[+A] extends ValueColumn[A] {
 }
 
 object TextColumn {
-  def apply(kind: TableauxDbType): (Table, ColumnId, String, Ordering, Boolean) => TextColumn = {
-    TextColumn(kind, _, _, _, _, _)
+  def apply(kind: TableauxDbType): (Table, ColumnId, String, Ordering, Boolean, Seq[DisplayInfo]) => TextColumn = {
+    TextColumn(kind, _, _, _, _, _, _)
   }
 }
 
-case class TextColumn(override val kind: TableauxDbType, table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean) extends SimpleValueColumn[String]
+case class TextColumn(override val kind: TableauxDbType, table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends SimpleValueColumn[String]
 
-case class NumberColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean) extends SimpleValueColumn[Number] {
+case class NumberColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends SimpleValueColumn[Number] {
   override val kind = NumericType
 }
 
-case class BooleanColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean) extends SimpleValueColumn[Boolean] {
+case class BooleanColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends SimpleValueColumn[Boolean] {
   override val kind = BooleanType
 }
 
-case class DateColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean) extends SimpleValueColumn[LocalDate] {
+case class DateColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends SimpleValueColumn[LocalDate] {
   override val kind = DateType
 }
 
-case class DateTimeColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean) extends SimpleValueColumn[DateTime] {
+case class DateTimeColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends SimpleValueColumn[DateTime] {
   override val kind = DateTimeType
 }
 
@@ -86,40 +98,40 @@ sealed trait MultiLanguageColumn[A] extends ValueColumn[A] {
 }
 
 object MultiTextColumn {
-  def apply(kind: TableauxDbType): (Table, ColumnId, String, Ordering, Boolean) => MultiTextColumn = {
-    MultiTextColumn(kind, _, _, _, _, _)
+  def apply(kind: TableauxDbType): (Table, ColumnId, String, Ordering, Boolean, Seq[DisplayInfo]) => MultiTextColumn = {
+    MultiTextColumn(kind, _, _, _, _, _, _)
   }
 }
 
-case class MultiTextColumn(override val kind: TableauxDbType, table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean) extends MultiLanguageColumn[String]
+case class MultiTextColumn(override val kind: TableauxDbType, table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends MultiLanguageColumn[String]
 
-case class MultiNumericColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean) extends MultiLanguageColumn[Number] {
+case class MultiNumericColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends MultiLanguageColumn[Number] {
   override val kind = NumericType
 }
 
-case class MultiBooleanColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean) extends MultiLanguageColumn[Boolean] {
+case class MultiBooleanColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends MultiLanguageColumn[Boolean] {
   override val kind = BooleanType
 }
 
-case class MultiDateColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean) extends MultiLanguageColumn[LocalDate] {
+case class MultiDateColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends MultiLanguageColumn[LocalDate] {
   override val kind = DateType
 }
 
-case class MultiDateTimeColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean) extends MultiLanguageColumn[DateTime] {
+case class MultiDateTimeColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends MultiLanguageColumn[DateTime] {
   override val kind = DateTimeType
 }
 
 /*
  * Special column types
  */
-case class LinkColumn[A](table: Table, id: ColumnId, to: ValueColumn[A], linkId: LinkId, linkDirection: LinkDirection, name: String, ordering: Ordering, override val identifier: Boolean) extends ColumnType[Link[A]] {
+case class LinkColumn[A](table: Table, id: ColumnId, to: ValueColumn[A], linkId: LinkId, linkDirection: LinkDirection, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends ColumnType[Link[A]] {
   override val kind = LinkType
   override val multilanguage = to.multilanguage
 
   override def getJson: JsonObject = super.getJson mergeIn Json.obj("toTable" -> to.table.id, "toColumn" -> to.getJson)
 }
 
-case class AttachmentColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean) extends ColumnType[AttachmentFile] {
+case class AttachmentColumn(table: Table, id: ColumnId, name: String, ordering: Ordering, override val identifier: Boolean, override val displayInfos: Seq[DisplayInfo]) extends ColumnType[AttachmentFile] {
   override val kind = AttachmentType
   override val multilanguage = false
 }
@@ -137,6 +149,7 @@ case class ConcatColumn(table: Table, name: String, columns: Seq[ColumnType[_]])
 
   override val id: ColumnId = 0
   override val ordering: Ordering = 0
+  override val displayInfos: Seq[DisplayInfo] = List()
 
   override def getJson: JsonObject = super.getJson mergeIn Json.obj("concats" -> columns.map(_.getJson))
 }
@@ -144,7 +157,7 @@ case class ConcatColumn(table: Table, name: String, columns: Seq[ColumnType[_]])
 /**
   * Column seq is just a sequence of columns.
   *
-  * @param columns
+  * @param columns The sequence of columns.
   */
 case class ColumnSeq(columns: Seq[ColumnType[_]]) extends DomainObject {
   override def getJson: JsonObject = Json.obj("columns" -> columns.map(_.getJson))

--- a/src/main/scala/com/campudus/tableaux/database/domain/createcolumn.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/createcolumn.scala
@@ -9,27 +9,33 @@ sealed trait CreateColumn {
   val languageType: LanguageType
   val ordering: Option[Ordering]
   val identifier: Boolean
+  val displayInfos: Seq[DisplayInfo]
 }
 
 case class CreateSimpleColumn(override val name: String,
                               override val ordering: Option[Ordering],
                               override val kind: TableauxDbType,
                               override val languageType: LanguageType,
-                              override val identifier: Boolean) extends CreateColumn
+                              override val identifier: Boolean,
+                              override val displayInfos: Seq[DisplayInfo]) extends CreateColumn
 
 case class CreateLinkColumn(override val name: String,
                             override val ordering: Option[Ordering],
                             toTable: TableId,
                             toName: Option[String],
                             singleDirection: Boolean,
-                            override val identifier: Boolean) extends CreateColumn {
+                            override val identifier: Boolean,
+                            override val displayInfos: Seq[DisplayInfo]) extends CreateColumn {
   override val kind = LinkType
   override val languageType = SingleLanguage
 }
 
 case class CreateAttachmentColumn(override val name: String,
                                   override val ordering: Option[Ordering],
-                                  override val identifier: Boolean) extends CreateColumn {
+                                  override val identifier: Boolean,
+                                  override val displayInfos: Seq[DisplayInfo]) extends CreateColumn {
   override val kind = AttachmentType
   override val languageType = SingleLanguage
 }
+
+case class ColumnInfo(tableId: TableId, columnId: ColumnId, ordering: Ordering, displayInfos: Seq[DisplayInfo] = List())

--- a/src/main/scala/com/campudus/tableaux/database/domain/displayInfo.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/displayInfo.scala
@@ -1,0 +1,74 @@
+package com.campudus.tableaux.database.domain
+
+import com.campudus.tableaux.database.model.TableauxModel._
+import org.vertx.scala.core.json._
+
+sealed trait DisplayInfo {
+  val langtag: String
+  val optionalName: Option[String]
+  val optionalDescription: Option[String]
+}
+
+case class NameOnly(langtag: String, name: String) extends DisplayInfo {
+  val optionalName = Some(name)
+  val optionalDescription = None
+}
+
+case class NameAndDescription(langtag: String, name: String, description: String) extends DisplayInfo {
+  val optionalName = Some(name)
+  val optionalDescription = Some(description)
+}
+
+case class DescriptionOnly(langtag: String, description: String) extends DisplayInfo {
+  val optionalName = None
+  val optionalDescription = Some(description)
+}
+
+class DisplayInfos(tableId: TableId, columnId: ColumnId, val entries: Seq[DisplayInfo]) {
+
+  def nonEmpty: Boolean = entries.nonEmpty
+
+  def statement: String = {
+    s"""INSERT INTO system_columns_lang (table_id, column_id, langtag, name, description)
+        |VALUES ${entries.map(_ => s"(?, ?, ?, ?, ?)").mkString(", ")}""".stripMargin
+  }
+
+  def binds: Seq[Any] = entries.flatMap {
+    di => List(tableId, columnId) ::: List(di.langtag, di.optionalName.orNull, di.optionalDescription.orNull)
+  }
+
+}
+
+object DisplayInfos {
+  def allInfos(json: JsonObject): Seq[DisplayInfo] = {
+    import scala.collection.JavaConverters._
+    val names = json.getJsonObject("displayName", Json.obj()).fieldNames().asScala
+    val descriptions = json.getJsonObject("description", Json.obj()).fieldNames().asScala
+    val both = names.intersect(descriptions) map { lang =>
+      NameAndDescription(lang,
+        json.getJsonObject("displayName").getString(lang),
+        json.getJsonObject("description").getString(lang))
+    }
+    val nameOnly = names.diff(descriptions) map { lang =>
+      NameOnly(lang, json.getJsonObject("displayName").getString(lang))
+    }
+    val descOnly = descriptions.diff(names) map { lang =>
+      DescriptionOnly(lang, json.getJsonObject("description").getString(lang))
+    }
+
+    both.toList ::: nameOnly.toList ::: descOnly.toList
+  }
+
+  def fromString(langtag: String, name: String, description: String): DisplayInfo = (langtag, name, description) match {
+    case (_, name, null) => NameOnly(langtag, name)
+    case (_, null, desc) => DescriptionOnly(langtag, description)
+    case (_, name, desc) => NameAndDescription(langtag, name, description)
+  }
+
+  def apply(tableId: TableId, columnId: ColumnId, entries: Seq[DisplayInfo]): DisplayInfos = {
+    new DisplayInfos(tableId, columnId, entries)
+  }
+
+  def apply(tableId: TableId, columnId: ColumnId, json: JsonObject): DisplayInfos =
+    apply(tableId, columnId, allInfos(json))
+}

--- a/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
@@ -98,11 +98,11 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
     /**
       * Change Column
       */
-    case Post(Column(tableId, columnId)) => asyncEmptyReply {
+    case Post(Column(tableId, columnId)) => asyncGetReply {
       for {
         json <- getJson(context)
-        (optName, optOrd, optKind, optIdent) = toColumnChanges(json)
-        changed <- controller.changeColumn(tableId.toLong, columnId.toLong, optName, optOrd, optKind, optIdent)
+        (optName, optOrd, optKind, optIdent, optDisplayNames, optDescription) = toColumnChanges(json)
+        changed <- controller.changeColumn(tableId.toLong, columnId.toLong, optName, optOrd, optKind, optIdent, optDisplayNames, optDescription)
       } yield changed
     }
 

--- a/src/test/scala/com/campudus/tableaux/ArgumentCheckerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/ArgumentCheckerTest.scala
@@ -156,4 +156,32 @@ class ArgumentCheckerTest {
       hasLong("no_long", json)
     )
   }
+
+  @Test
+  def checkForAllObjectValues(): Unit = {
+
+    val okJson1 = Json.obj("de_DE" -> "Eine beliebige Zeichenkette")
+    val okJson2 = Json.obj("de_DE" -> "Eine beliebige Zeichenkette", "en_US" -> "A random string")
+    val okJson3 = Json.obj()
+    val failJson1 = Json.obj("de_DE" -> false)
+    val failJson2 = Json.obj("de_DE" -> "Eine beliebige Zeichenkette", "en_US" -> true)
+    val failJson3 = Json.obj("de_DE" -> null)
+
+    assertEquals(OkArg(okJson1), checkForAllValues[String](okJson1, _.isInstanceOf[String], "obj1"))
+    assertEquals(OkArg(okJson2), checkForAllValues[String](okJson2, _.isInstanceOf[String], "obj2"))
+    assertEquals(OkArg(okJson3), checkForAllValues[String](okJson3, _.isInstanceOf[String], "obj3"))
+
+    assertEquals(FailArg(InvalidJsonException(
+      "Warning: obj4 has incorrectly typed value at key 'de_DE'.", "invalid")),
+      checkForAllValues[String](failJson1, _.isInstanceOf[String], "obj4"))
+
+    assertEquals(FailArg(InvalidJsonException(
+      "Warning: obj5 has incorrectly typed value at key 'en_US'.", "invalid")),
+      checkForAllValues[String](failJson2, _.isInstanceOf[String], "obj5"))
+
+    assertEquals(FailArg(InvalidJsonException(
+      "Warning: obj6 has value 'de_DE' pointing at null.", "invalid")),
+      checkForAllValues[String](failJson3, _.isInstanceOf[String], "obj6"))
+
+  }
 }

--- a/src/test/scala/com/campudus/tableaux/ChangeTest.scala
+++ b/src/test/scala/com/campudus/tableaux/ChangeTest.scala
@@ -35,11 +35,11 @@ class ChangeTest extends TableauxTestBase {
 
     for {
       _ <- setupDefaultTable()
-      test <- sendRequest("POST", "/tables/1/columns/1", postJson)
-      test2 <- sendRequest("GET", "/tables/1/columns/1")
+      resultPost <- sendRequest("POST", "/tables/1/columns/1", postJson)
+      resultGet <- sendRequest("GET", "/tables/1/columns/1")
     } yield {
-      assertEquals(expectedJson, test)
-      assertEquals(expectedString, test2.getString("name"))
+      assertEquals(expectedString, resultGet.getString("name"))
+      assertEquals(resultPost, resultGet)
     }
   }
 
@@ -50,11 +50,11 @@ class ChangeTest extends TableauxTestBase {
 
     for {
       _ <- setupDefaultTable()
-      test <- sendRequest("POST", "/tables/1/columns/1", postJson)
-      test2 <- sendRequest("GET", "/tables/1/columns/1")
+      resultPost <- sendRequest("POST", "/tables/1/columns/1", postJson)
+      resultGet <- sendRequest("GET", "/tables/1/columns/1")
     } yield {
-      assertEquals(expectedJson, test)
-      assertEquals(expectedOrdering, test2.getInteger("ordering"))
+      assertEquals(expectedOrdering, resultGet.getInteger("ordering"))
+      assertEquals(resultPost, resultGet)
     }
   }
 
@@ -65,11 +65,11 @@ class ChangeTest extends TableauxTestBase {
 
     for {
       _ <- setupDefaultTable()
-      test <- sendRequest("POST", "/tables/1/columns/2", postJson)
-      test2 <- sendRequest("GET", "/tables/1/columns/2")
+      resultPost <- sendRequest("POST", "/tables/1/columns/2", postJson)
+      resultGet <- sendRequest("GET", "/tables/1/columns/2")
     } yield {
-      assertEquals(expectedJson, test)
-      assertEquals(expectedKind, test2.getString("kind"))
+      assertEquals(expectedKind, resultGet.getString("kind"))
+      assertEquals(resultPost, resultGet)
     }
   }
 
@@ -98,7 +98,7 @@ class ChangeTest extends TableauxTestBase {
 
       columns <- sendRequest("GET", "/tables/1/columns")
     } yield {
-      assertEquals(expectedJson, changeToText)
+      assertEquals(columns.getJsonArray("columns").getJsonObject(1).mergeIn(Json.obj("status" -> "ok")), changeToText)
 
       assertEquals(failed, failedChangeToNumeric)
 
@@ -110,15 +110,15 @@ class ChangeTest extends TableauxTestBase {
   @Test
   def changeColumn(implicit c: TestContext): Unit = okTest {
     val postJson = Json.obj("name" -> "New testname", "ordering" -> 5, "kind" -> "text")
-    val expectedJson2 = Json.obj("status" -> "ok", "id" -> 2, "name" -> "New testname", "kind" -> "text", "ordering" -> 5, "multilanguage" -> false, "identifier" -> false)
+    val expectedJson2 = Json.obj("status" -> "ok", "id" -> 2, "name" -> "New testname", "kind" -> "text", "ordering" -> 5, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj())
 
     for {
-      _ <- setupDefaultTable()
-      test <- sendRequest("POST", "/tables/1/columns/2", postJson)
-      test2 <- sendRequest("GET", "/tables/1/columns/2")
+      tableId <- setupDefaultTable()
+      resultPost <- sendRequest("POST", s"/tables/$tableId/columns/2", postJson)
+      resultGet <- sendRequest("GET", s"/tables/$tableId/columns/2")
     } yield {
-      assertEquals(expectedJson, test)
-      assertEquals(expectedJson2, test2)
+      assertEquals(expectedJson2, resultGet)
+      assertEquals(resultPost, resultGet)
     }
   }
 }

--- a/src/test/scala/com/campudus/tableaux/ColumnNameAndDescriptionTest.scala
+++ b/src/test/scala/com/campudus/tableaux/ColumnNameAndDescriptionTest.scala
@@ -1,0 +1,343 @@
+package com.campudus.tableaux
+
+import io.vertx.ext.unit.TestContext
+import io.vertx.ext.unit.junit.VertxUnitRunner
+import org.junit.runner.RunWith
+import org.junit.{Ignore, Test}
+import org.vertx.scala.core.json.Json
+
+@RunWith(classOf[VertxUnitRunner])
+class ColumnNameAndDescriptionTest extends TableauxTestBase {
+
+  @Test
+  def createMultilanguageNamesForColumn(implicit c: TestContext): Unit = okTest {
+    val postSimpleTable = Json.obj("name" -> "table1")
+    val columnWithDisplayName = Json.obj(
+      "name" -> "column1",
+      "kind" -> "shorttext",
+      "displayName" -> Json.obj(
+        "de_DE" -> "Spalte Eins",
+        "en_US" -> "Column One"
+      )
+    )
+    val postColumnWithDisplayNames = Json.obj("columns" -> Json.arr(columnWithDisplayName))
+
+    for {
+      table <- sendRequest("POST", "/tables", postSimpleTable)
+      tableId = table.getLong("id")
+
+      postColumnResult <- sendRequest("POST", s"/tables/$tableId/columns", postColumnWithDisplayNames)
+      columnId = postColumnResult.getJsonArray("columns").getJsonObject(0).getLong("id")
+
+      getColumnResult <- sendRequest("GET", s"/tables/$tableId/columns/$columnId")
+    } yield {
+      assertContains(columnWithDisplayName, postColumnResult.getJsonArray("columns").getJsonObject(0))
+      assertEquals(getColumnResult, postColumnResult.getJsonArray("columns").getJsonObject(0).mergeIn(Json.obj("status" -> "ok")))
+    }
+  }
+
+  @Test
+  def changeMultilanguageNamesForColumn(implicit c: TestContext): Unit = okTest {
+    val postSimpleTable = Json.obj("name" -> "table1")
+    val columnWithDisplayName = Json.obj(
+      "name" -> "column1",
+      "kind" -> "shorttext",
+      "displayName" -> Json.obj(
+        "de_DE" -> "Spalte Eins",
+        "en_US" -> "Column One"
+      )
+    )
+    val columnWithDisplayName2 = Json.obj(
+      "displayName" -> Json.obj(
+        "de_DE" -> "Erste Spalte",
+        "en_US" -> "First column"
+      )
+    )
+    val postColumnWithDisplayNames = Json.obj("columns" -> Json.arr(columnWithDisplayName))
+
+    for {
+      table <- sendRequest("POST", "/tables", postSimpleTable)
+      tableId = table.getLong("id")
+
+      postColumnResult <- sendRequest("POST", s"/tables/$tableId/columns", postColumnWithDisplayNames)
+      createResult = postColumnResult.getJsonArray("columns").getJsonObject(0)
+      columnId = createResult.getLong("id")
+
+      changedResult <- sendRequest("POST", s"/tables/$tableId/columns/$columnId", columnWithDisplayName2)
+      getColumnResult <- sendRequest("GET", s"/tables/$tableId/columns/$columnId")
+    } yield {
+      assertContains(columnWithDisplayName, createResult)
+      assertContains(columnWithDisplayName2, changedResult)
+      assertEquals(getColumnResult, changedResult.mergeIn(Json.obj("status" -> "ok")))
+    }
+  }
+
+  @Test
+  def addOtherLanguageDisplayNameToColumnShouldNotDeleteOtherLanguages(implicit c: TestContext): Unit = okTest {
+    val postSimpleTable = Json.obj("name" -> "table1")
+    val columnWithDisplayName = Json.obj(
+      "name" -> "column1",
+      "kind" -> "shorttext",
+      "displayName" -> Json.obj(
+        "de_DE" -> "Spalte Eins"
+      )
+    )
+    val columnWithDisplayName2 = Json.obj(
+      "displayName" -> Json.obj(
+        "en_US" -> "Column One"
+      )
+    )
+    val postColumnWithDisplayNames = Json.obj("columns" -> Json.arr(columnWithDisplayName))
+
+    for {
+      table <- sendRequest("POST", "/tables", postSimpleTable)
+      tableId = table.getLong("id")
+
+      postColumnResult <- sendRequest("POST", s"/tables/$tableId/columns", postColumnWithDisplayNames)
+      createResult = postColumnResult.getJsonArray("columns").getJsonObject(0)
+      columnId = createResult.getLong("id")
+
+      changedResult <- sendRequest("POST", s"/tables/$tableId/columns/$columnId", columnWithDisplayName2)
+      getColumnResult <- sendRequest("GET", s"/tables/$tableId/columns/$columnId")
+    } yield {
+      logger.info(s"changedResult=${changedResult.encode()}")
+      assertContains(columnWithDisplayName, createResult)
+      assertEquals(Json.obj("de_DE" -> "Spalte Eins", "en_US" -> "Column One"), changedResult.getJsonObject("displayName"))
+      assertEquals(changedResult.mergeIn(Json.obj("status" -> "ok")), getColumnResult)
+    }
+  }
+
+  @Test
+  def deleteLanguageFromDisplayName(implicit c: TestContext): Unit = okTest {
+    val postSimpleTable = Json.obj("name" -> "table1")
+    val columnWithDisplayName = Json.obj(
+      "name" -> "column1",
+      "kind" -> "shorttext",
+      "displayName" -> Json.obj(
+        "de_DE" -> "Spalte Eins",
+        "en_US" -> "Column One"
+      )
+    )
+    val columnWithDisplayName2 = Json.obj(
+      "displayName" -> Json.obj(
+        "en_US" -> null
+      )
+    )
+    val postColumnWithDisplayNames = Json.obj("columns" -> Json.arr(columnWithDisplayName))
+
+    for {
+      table <- sendRequest("POST", "/tables", postSimpleTable)
+      tableId = table.getLong("id")
+
+      postColumnResult <- sendRequest("POST", s"/tables/$tableId/columns", postColumnWithDisplayNames)
+      createResult = postColumnResult.getJsonArray("columns").getJsonObject(0)
+      columnId = createResult.getLong("id")
+
+      changedResult <- sendRequest("POST", s"/tables/$tableId/columns/$columnId", columnWithDisplayName2)
+      getColumnResult <- sendRequest("GET", s"/tables/$tableId/columns/$columnId")
+    } yield {
+      assertContains(columnWithDisplayName, createResult)
+      assertEquals(Json.obj("de_DE" -> "Spalte Eins"), changedResult.getJsonObject("displayName"))
+      assertEquals(getColumnResult, changedResult.mergeIn(Json.obj("status" -> "ok")))
+    }
+  }
+
+  @Test
+  def createMultilanguageNameAndDescriptionForColumn(implicit c: TestContext): Unit = okTest {
+    val postSimpleTable = Json.obj("name" -> "table1")
+    val columnWithDisplayNameAndDescription = Json.obj(
+      "name" -> "column1",
+      "kind" -> "shorttext",
+      "displayName" -> Json.obj(
+        "de_DE" -> "Spalte 1",
+        "en_US" -> "Column 1"
+      ),
+      "description" -> Json.obj(
+        "de_DE" -> "Beschreibung Spalte 1",
+        "en_US" -> "Description Column 1"
+      )
+    )
+    val postColumnWithDisplayNames = Json.obj("columns" -> Json.arr(columnWithDisplayNameAndDescription))
+
+    for {
+      table <- sendRequest("POST", "/tables", postSimpleTable)
+      tableId = table.getLong("id")
+
+      postColumnResult <- sendRequest("POST", s"/tables/$tableId/columns", postColumnWithDisplayNames)
+      columnId = postColumnResult.getJsonArray("columns").getJsonObject(0).getLong("id")
+
+      getColumnResult <- sendRequest("GET", s"/tables/$tableId/columns/$columnId")
+    } yield {
+      assertContains(columnWithDisplayNameAndDescription, postColumnResult.getJsonArray("columns").getJsonObject(0))
+      assertEquals(getColumnResult, postColumnResult.getJsonArray("columns").getJsonObject(0).mergeIn(Json.obj("status" -> "ok")))
+    }
+  }
+
+  @Test
+  def changeMultilanguageNameAndDescriptionForColumn(implicit c: TestContext): Unit = okTest {
+    val postSimpleTable = Json.obj("name" -> "table1")
+    val columnWithDisplayNameAndDescription = Json.obj(
+      "name" -> "column1",
+      "kind" -> "shorttext",
+      "displayName" -> Json.obj(
+        "de_DE" -> "Spalte 1",
+        "en_US" -> "Column 1",
+        "fr_FR" -> "Colonne 1"
+      ),
+      "description" -> Json.obj(
+        "de_DE" -> "Beschreibung Spalte 1",
+        "en_US" -> "Description column 1",
+        "fr_FR" -> "Description colonne 1"
+      )
+    )
+    val columnWithDisplayName2 = Json.obj(
+      "displayName" -> Json.obj(
+        "en_US" -> "First column",
+        "fr_FR" -> "Première colonne"
+      ),
+      "description" -> Json.obj(
+        "de_DE" -> "Beschreibung Spalte Eins",
+        "fr_FR" -> "Description première colonne"
+      )
+    )
+    val postColumnWithDisplayNames = Json.obj("columns" -> Json.arr(columnWithDisplayNameAndDescription))
+
+    for {
+      table <- sendRequest("POST", "/tables", postSimpleTable)
+      tableId = table.getLong("id")
+
+      postColumnResult <- sendRequest("POST", s"/tables/$tableId/columns", postColumnWithDisplayNames)
+      columnId = postColumnResult.getJsonArray("columns").getJsonObject(0).getLong("id")
+
+      changedResult <- sendRequest("POST", s"/tables/$tableId/columns/$columnId", columnWithDisplayName2)
+      getColumnResult <- sendRequest("GET", s"/tables/$tableId/columns/$columnId")
+    } yield {
+      assertContains(columnWithDisplayNameAndDescription, postColumnResult.getJsonArray("columns").getJsonObject(0))
+      assertContains(Json.obj("displayName" -> Json.obj(
+        "de_DE" -> "Spalte 1",
+        "en_US" -> "First column",
+        "fr_FR" -> "Première colonne"
+      ),
+        "description" -> Json.obj(
+          "de_DE" -> "Beschreibung Spalte Eins",
+          "en_US" -> "Description column 1",
+          "fr_FR" -> "Description première colonne"
+        )
+      ), changedResult)
+      assertEquals(changedResult, getColumnResult)
+    }
+  }
+
+  @Test
+  def deleteAllDisplayNamesAndDescriptionsForColumn(implicit c: TestContext): Unit = okTest {
+    val postSimpleTable = Json.obj("name" -> "table1")
+    val columnWithDisplayNameAndDescription = Json.obj(
+      "name" -> "column1",
+      "kind" -> "shorttext",
+      "displayName" -> Json.obj(
+        "de_DE" -> "Spalte 1",
+        "en_US" -> "Column 1"
+      ),
+      "description" -> Json.obj(
+        "de_DE" -> "Beschreibung Spalte 1",
+        "en_US" -> "Description Column 1"
+      )
+    )
+    val columnWithNulledValues = Json.obj(
+      "displayName" -> Json.obj(
+        "de_DE" -> null,
+        "en_US" -> null
+      ),
+      "description" -> Json.obj(
+        "de_DE" -> null,
+        "en_US" -> null
+      )
+    )
+    val postColumnWithDisplayNames = Json.obj("columns" -> Json.arr(columnWithDisplayNameAndDescription))
+
+    for {
+      table <- sendRequest("POST", "/tables", postSimpleTable)
+      tableId = table.getLong("id")
+
+      postColumnResult <- sendRequest("POST", s"/tables/$tableId/columns", postColumnWithDisplayNames)
+      columnId = postColumnResult.getJsonArray("columns").getJsonObject(0).getLong("id")
+
+      changedResult <- sendRequest("POST", s"/tables/$tableId/columns/$columnId", columnWithNulledValues)
+      getColumnResult <- sendRequest("GET", s"/tables/$tableId/columns/$columnId")
+    } yield {
+      assertContains(columnWithDisplayNameAndDescription, postColumnResult.getJsonArray("columns").getJsonObject(0))
+      logger.info(s"changedResult=${changedResult.encode()}")
+      assertContains(Json.obj("displayName" -> Json.obj(), "description" -> Json.obj()), changedResult)
+      assertEquals(changedResult, getColumnResult)
+    }
+  }
+
+  @Test
+  def createMultilanguageNameAndOtherDescriptionForColumn(implicit c: TestContext): Unit = okTest {
+    val postSimpleTable = Json.obj("name" -> "table1")
+    val columnWithDisplayNameAndDescription = Json.obj(
+      "name" -> "column1",
+      "kind" -> "shorttext",
+      "displayName" -> Json.obj(
+        "de_DE" -> "Spalte 1"
+      ),
+      "description" -> Json.obj(
+        "en_US" -> "Description Column 1"
+      )
+    )
+    val postColumnWithDisplayNames = Json.obj("columns" -> Json.arr(columnWithDisplayNameAndDescription))
+
+    for {
+      table <- sendRequest("POST", "/tables", postSimpleTable)
+      tableId = table.getLong("id")
+
+      postColumnResult <- sendRequest("POST", s"/tables/$tableId/columns", postColumnWithDisplayNames)
+      columnId = postColumnResult.getJsonArray("columns").getJsonObject(0).getLong("id")
+
+      getColumnResult <- sendRequest("GET", s"/tables/$tableId/columns/$columnId")
+    } yield {
+      assertContains(columnWithDisplayNameAndDescription, postColumnResult.getJsonArray("columns").getJsonObject(0))
+      assertEquals(getColumnResult, postColumnResult.getJsonArray("columns").getJsonObject(0).mergeIn(Json.obj("status" -> "ok")))
+    }
+  }
+
+  @Ignore("not implemented yet")
+  @Test
+  def changeMultilanguageNameAndOtherDescriptionForColumn(implicit c: TestContext): Unit = okTest {
+    ???
+  }
+
+  @Test
+  def createMultilanguageDescriptionForColumn(implicit c: TestContext): Unit = okTest {
+    val postSimpleTable = Json.obj("name" -> "table1")
+    val columnWithDescription = Json.obj(
+      "name" -> "column1",
+      "kind" -> "shorttext",
+      "description" -> Json.obj(
+        "de_DE" -> "Beschreibung Spalte 1",
+        "en_US" -> "Description Column 1"
+      )
+    )
+    val postColumnWithDisplayNames = Json.obj("columns" -> Json.arr(columnWithDescription))
+
+    for {
+      table <- sendRequest("POST", "/tables", postSimpleTable)
+      tableId = table.getLong("id")
+
+      postColumnResult <- sendRequest("POST", s"/tables/$tableId/columns", postColumnWithDisplayNames)
+      columnId = postColumnResult.getJsonArray("columns").getJsonObject(0).getLong("id")
+
+      getColumnResult <- sendRequest("GET", s"/tables/$tableId/columns/$columnId")
+    } yield {
+      assertContains(columnWithDescription, postColumnResult.getJsonArray("columns").getJsonObject(0))
+      assertEquals(getColumnResult, postColumnResult.getJsonArray("columns").getJsonObject(0).mergeIn(Json.obj("status" -> "ok")))
+    }
+  }
+
+  @Ignore("not implemented yet")
+  @Test
+  def changeMultilanguageDescriptionForColumn(implicit c: TestContext): Unit = okTest {
+    ???
+  }
+
+}

--- a/src/test/scala/com/campudus/tableaux/CreationTest.scala
+++ b/src/test/scala/com/campudus/tableaux/CreationTest.scala
@@ -2,13 +2,12 @@ package com.campudus.tableaux
 
 import java.util
 
-import com.campudus.tableaux.testtools.RequestCreation
-import com.campudus.tableaux.testtools.RequestCreation.{Text, Identifier}
+import com.campudus.tableaux.testtools.RequestCreation.{Identifier, Text}
 import io.vertx.ext.unit.TestContext
 import io.vertx.ext.unit.junit.VertxUnitRunner
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.vertx.scala.core.json.{JsonArray, Json}
+import org.vertx.scala.core.json.Json
 
 import scala.concurrent.Future
 
@@ -40,8 +39,8 @@ class CreationTest extends TableauxTestBase {
 
   @Test
   def createTextColumn(implicit c: TestContext): Unit = okTest {
-    val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 1, "ordering" -> 1, "multilanguage" -> false, "identifier" -> false).mergeIn(createTextColumnJson.getJsonArray("columns").getJsonObject(0))))
-    val expectedJson2 = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 2, "ordering" -> 2, "multilanguage" -> false, "identifier" -> false).mergeIn(createTextColumnJson.getJsonArray("columns").getJsonObject(0))))
+    val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 1, "ordering" -> 1, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()).mergeIn(createTextColumnJson.getJsonArray("columns").getJsonObject(0))))
+    val expectedJson2 = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 2, "ordering" -> 2, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()).mergeIn(createTextColumnJson.getJsonArray("columns").getJsonObject(0))))
 
     for {
       _ <- sendRequest("POST", "/tables", createTableJson)
@@ -55,8 +54,8 @@ class CreationTest extends TableauxTestBase {
 
   @Test
   def createShortTextColumn(implicit c: TestContext): Unit = okTest {
-    val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 1, "ordering" -> 1, "multilanguage" -> false, "identifier" -> false).mergeIn(createShortTextColumnJson.getJsonArray("columns").getJsonObject(0))))
-    val expectedJson2 = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 2, "ordering" -> 2, "multilanguage" -> false, "identifier" -> false).mergeIn(createShortTextColumnJson.getJsonArray("columns").getJsonObject(0))))
+    val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 1, "ordering" -> 1, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()).mergeIn(createShortTextColumnJson.getJsonArray("columns").getJsonObject(0))))
+    val expectedJson2 = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 2, "ordering" -> 2, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()).mergeIn(createShortTextColumnJson.getJsonArray("columns").getJsonObject(0))))
 
     for {
       _ <- sendRequest("POST", "/tables", createTableJson)
@@ -70,8 +69,8 @@ class CreationTest extends TableauxTestBase {
 
   @Test
   def createRichTextColumn(implicit c: TestContext): Unit = okTest {
-    val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 1, "ordering" -> 1, "multilanguage" -> false, "identifier" -> false).mergeIn(createRichTextColumnJson.getJsonArray("columns").getJsonObject(0))))
-    val expectedJson2 = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 2, "ordering" -> 2, "multilanguage" -> false, "identifier" -> false).mergeIn(createRichTextColumnJson.getJsonArray("columns").getJsonObject(0))))
+    val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 1, "ordering" -> 1, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()).mergeIn(createRichTextColumnJson.getJsonArray("columns").getJsonObject(0))))
+    val expectedJson2 = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 2, "ordering" -> 2, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()).mergeIn(createRichTextColumnJson.getJsonArray("columns").getJsonObject(0))))
 
     for {
       _ <- sendRequest("POST", "/tables", createTableJson)
@@ -85,8 +84,8 @@ class CreationTest extends TableauxTestBase {
 
   @Test
   def createNumberColumn(implicit c: TestContext): Unit = okTest {
-    val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 1, "ordering" -> 1, "multilanguage" -> false, "identifier" -> false).mergeIn(createNumberColumnJson.getJsonArray("columns").getJsonObject(0))))
-    val expectedJson2 = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 2, "ordering" -> 2, "multilanguage" -> false, "identifier" -> false).mergeIn(createNumberColumnJson.getJsonArray("columns").getJsonObject(0))))
+    val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 1, "ordering" -> 1, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()).mergeIn(createNumberColumnJson.getJsonArray("columns").getJsonObject(0))))
+    val expectedJson2 = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 2, "ordering" -> 2, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()).mergeIn(createNumberColumnJson.getJsonArray("columns").getJsonObject(0))))
 
     for {
       _ <- sendRequest("POST", "/tables", createTableJson)
@@ -100,8 +99,8 @@ class CreationTest extends TableauxTestBase {
 
   @Test
   def createBooleanColumn(implicit c: TestContext): Unit = okTest {
-    val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 1, "ordering" -> 1, "multilanguage" -> false, "identifier" -> false).mergeIn(createBooleanColumnJson.getJsonArray("columns").getJsonObject(0))))
-    val expectedJson2 = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 2, "ordering" -> 2, "multilanguage" -> false, "identifier" -> false).mergeIn(createBooleanColumnJson.getJsonArray("columns").getJsonObject(0))))
+    val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 1, "ordering" -> 1, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()).mergeIn(createBooleanColumnJson.getJsonArray("columns").getJsonObject(0))))
+    val expectedJson2 = Json.obj("status" -> "ok", "columns" -> Json.arr(Json.obj("id" -> 2, "ordering" -> 2, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()).mergeIn(createBooleanColumnJson.getJsonArray("columns").getJsonObject(0))))
 
     for {
       _ <- sendRequest("POST", "/tables", createTableJson)
@@ -120,8 +119,8 @@ class CreationTest extends TableauxTestBase {
       Json.obj("kind" -> "text", "name" -> "Test Column 2")))
 
     val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(
-      Json.obj("id" -> 1, "ordering" -> 1, "kind" -> "numeric", "name" -> "Test Column 1", "multilanguage" -> false, "identifier" -> false),
-      Json.obj("id" -> 2, "ordering" -> 2, "kind" -> "text", "name" -> "Test Column 2", "multilanguage" -> false, "identifier" -> false)))
+      Json.obj("id" -> 1, "ordering" -> 1, "kind" -> "numeric", "name" -> "Test Column 1", "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()),
+      Json.obj("id" -> 2, "ordering" -> 2, "kind" -> "text", "name" -> "Test Column 2", "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj())))
 
     for {
       _ <- sendRequest("POST", "/tables", createTableJson)
@@ -137,8 +136,8 @@ class CreationTest extends TableauxTestBase {
       Json.obj("kind" -> "numeric", "name" -> "Test Column 1", "ordering" -> 2),
       Json.obj("kind" -> "text", "name" -> "Test Column 2", "ordering" -> 1)))
     val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(
-      Json.obj("id" -> 2, "ordering" -> 1, "kind" -> "text", "name" -> "Test Column 2", "multilanguage" -> false, "identifier" -> false),
-      Json.obj("id" -> 1, "ordering" -> 2, "kind" -> "numeric", "name" -> "Test Column 1", "multilanguage" -> false, "identifier" -> false)))
+      Json.obj("id" -> 2, "ordering" -> 1, "kind" -> "text", "name" -> "Test Column 2", "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()),
+      Json.obj("id" -> 1, "ordering" -> 2, "kind" -> "numeric", "name" -> "Test Column 1", "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj())))
 
     for {
       _ <- sendRequest("POST", "/tables", createTableJson)
@@ -387,8 +386,8 @@ class CreationTest extends TableauxTestBase {
       "status" -> "ok",
       "id" -> 1,
       "columns" -> Json.arr(
-        Json.obj("id" -> 1, "ordering" -> 1, "kind" -> "text", "name" -> "Test Column 1", "multilanguage" -> false, "identifier" -> false),
-        Json.obj("id" -> 2, "ordering" -> 2, "kind" -> "numeric", "name" -> "Test Column 2", "multilanguage" -> false, "identifier" -> false)),
+        Json.obj("id" -> 1, "ordering" -> 1, "kind" -> "text", "name" -> "Test Column 1", "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()),
+        Json.obj("id" -> 2, "ordering" -> 2, "kind" -> "numeric", "name" -> "Test Column 2", "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj())),
       "rows" -> Json.arr(
         Json.obj("id" -> 1, "values" -> Json.arr("Test Field 1", 1)),
         Json.obj("id" -> 2, "values" -> Json.arr("Test Field 2", 2))))
@@ -414,8 +413,8 @@ class CreationTest extends TableauxTestBase {
     val expectedJson = Json.obj(
       "id" -> 1,
       "columns" -> Json.arr(
-        Json.obj("id" -> 2, "ordering" -> 1, "kind" -> "numeric", "name" -> "Test Column 2", "multilanguage" -> false, "identifier" -> false),
-        Json.obj("id" -> 1, "ordering" -> 2, "kind" -> "text", "name" -> "Test Column 1", "multilanguage" -> false, "identifier" -> false)
+        Json.obj("id" -> 2, "ordering" -> 1, "kind" -> "numeric", "name" -> "Test Column 2", "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()),
+        Json.obj("id" -> 1, "ordering" -> 2, "kind" -> "text", "name" -> "Test Column 1", "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj())
       ),
       "rows" -> Json.arr(
         Json.obj("id" -> 1, "values" -> Json.arr(1, "Test Field 1")),
@@ -439,8 +438,8 @@ class CreationTest extends TableauxTestBase {
     val expectedJson = Json.obj(
       "id" -> 1,
       "columns" -> Json.arr(
-        Json.obj("id" -> 1, "ordering" -> 1, "kind" -> "text", "name" -> "Test Column 1", "multilanguage" -> false, "identifier" -> false),
-        Json.obj("id" -> 2, "ordering" -> 2, "kind" -> "numeric", "name" -> "Test Column 2", "multilanguage" -> false, "identifier" -> false)),
+        Json.obj("id" -> 1, "ordering" -> 1, "kind" -> "text", "name" -> "Test Column 1", "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()),
+        Json.obj("id" -> 2, "ordering" -> 2, "kind" -> "numeric", "name" -> "Test Column 2", "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj())),
       "rows" -> Json.arr())
 
     for {

--- a/src/test/scala/com/campudus/tableaux/GetTest.scala
+++ b/src/test/scala/com/campudus/tableaux/GetTest.scala
@@ -46,9 +46,9 @@ class GetTest extends TableauxTestBase {
       "name" -> "Test Table 1",
       "hidden" -> false,
       "columns" -> Json.arr(
-        Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> false),
-        Json.obj("id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2, "multilanguage" -> false, "identifier" -> false),
-        Json.obj("id" -> 3, "name" -> "Test Column 3", "kind" -> "boolean", "ordering" -> 3, "multilanguage" -> false, "identifier" -> false)),
+        Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()),
+        Json.obj("id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()),
+        Json.obj("id" -> 3, "name" -> "Test Column 3", "kind" -> "boolean", "ordering" -> 3, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj())),
       "page" -> Json.obj(
         "offset" -> null,
         "limit" -> null,
@@ -75,9 +75,9 @@ class GetTest extends TableauxTestBase {
       "name" -> "Test Table 1",
       "hidden" -> false,
       "columns" -> Json.arr(
-        Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> false),
-        Json.obj("id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2, "multilanguage" -> false, "identifier" -> false),
-        Json.obj("id" -> 3, "name" -> "Test Column 3", "kind" -> "boolean", "ordering" -> 3, "multilanguage" -> false, "identifier" -> false)),
+        Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()),
+        Json.obj("id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()),
+        Json.obj("id" -> 3, "name" -> "Test Column 3", "kind" -> "boolean", "ordering" -> 3, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj())),
       "page" -> Json.obj(
         "offset" -> null,
         "limit" -> null,
@@ -101,9 +101,9 @@ class GetTest extends TableauxTestBase {
   @Test
   def retrieveFullTable(implicit c: TestContext): Unit = okTest {
     val columns = Json.arr(
-      Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> false),
-      Json.obj("id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2, "multilanguage" -> false, "identifier" -> false),
-      Json.obj("id" -> 3, "name" -> "Test Column 3", "kind" -> "boolean", "ordering" -> 3, "multilanguage" -> false, "identifier" -> false)
+      Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()),
+      Json.obj("id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj()),
+      Json.obj("id" -> 3, "name" -> "Test Column 3", "kind" -> "boolean", "ordering" -> 3, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj())
     )
 
     val rows = Json.arr(
@@ -180,8 +180,8 @@ class GetTest extends TableauxTestBase {
   @Test
   def retrieveColumns(implicit c: TestContext): Unit = okTest {
     val expectedJson = Json.obj("status" -> "ok", "columns" -> Json.arr(
-      Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> true),
-      Json.obj("id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2, "multilanguage" -> false, "identifier" -> false)
+      Json.obj("id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> true, "displayName" -> Json.obj(), "description" -> Json.obj()),
+      Json.obj("id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj())
     ))
 
     for {
@@ -194,7 +194,7 @@ class GetTest extends TableauxTestBase {
 
   @Test
   def retrieveStringColumn(implicit c: TestContext): Unit = okTest {
-    val expectedJson = Json.obj("status" -> "ok", "id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> true)
+    val expectedJson = Json.obj("status" -> "ok", "id" -> 1, "name" -> "Test Column 1", "kind" -> "text", "ordering" -> 1, "multilanguage" -> false, "identifier" -> true, "displayName" -> Json.obj(), "description" -> Json.obj())
 
     for {
       _ <- setupDefaultTable()
@@ -206,7 +206,7 @@ class GetTest extends TableauxTestBase {
 
   @Test
   def retrieveNumberColumn(implicit c: TestContext): Unit = okTest {
-    val expectedJson = Json.obj("status" -> "ok", "id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2, "multilanguage" -> false, "identifier" -> false)
+    val expectedJson = Json.obj("status" -> "ok", "id" -> 2, "name" -> "Test Column 2", "kind" -> "numeric", "ordering" -> 2, "multilanguage" -> false, "identifier" -> false, "displayName" -> Json.obj(), "description" -> Json.obj())
 
     for {
       _ <- setupDefaultTable()

--- a/src/test/scala/com/campudus/tableaux/LinkTest.scala
+++ b/src/test/scala/com/campudus/tableaux/LinkTest.scala
@@ -29,10 +29,14 @@ class LinkTest extends TableauxTestBase {
         "name" -> "Test Column 1",
         "kind" -> "text",
         "multilanguage" -> false,
-        "identifier" -> true
+        "identifier" -> true,
+        "displayName" -> Json.obj(),
+        "description" -> Json.obj()
       ),
       "ordering" -> 3,
-      "identifier" -> false
+      "identifier" -> false,
+      "displayName" -> Json.obj(),
+      "description" -> Json.obj()
     )
 
     for {
@@ -54,13 +58,17 @@ class LinkTest extends TableauxTestBase {
         "kind" -> "link",
         "multilanguage" -> false,
         "identifier" -> false,
+        "displayName" -> Json.obj(),
+        "description" -> Json.obj(),
         "toTable" -> 2,
         "toColumn" -> Json.obj(
           "id" -> 1, "ordering" -> 1,
           "kind" -> "text",
           "name" -> "Test Column 1",
           "multilanguage" -> false,
-          "identifier" -> true
+          "identifier" -> true,
+          "displayName" -> Json.obj(),
+          "description" -> Json.obj()
         ))))
 
     for {
@@ -82,13 +90,17 @@ class LinkTest extends TableauxTestBase {
         "kind" -> "link",
         "multilanguage" -> false,
         "identifier" -> false,
+        "displayName" -> Json.obj(),
+        "description" -> Json.obj(),
         "toTable" -> 2,
         "toColumn" -> Json.obj(
           "id" -> 1, "ordering" -> 1,
           "kind" -> "text",
           "name" -> "Test Column 1",
           "multilanguage" -> false,
-          "identifier" -> true
+          "identifier" -> true,
+          "displayName" -> Json.obj(),
+          "description" -> Json.obj()
         ))))
 
     for {
@@ -120,13 +132,17 @@ class LinkTest extends TableauxTestBase {
         "kind" -> "link",
         "multilanguage" -> false,
         "identifier" -> false,
+        "displayName" -> Json.obj(),
+        "description" -> Json.obj(),
         "toTable" -> 2,
         "toColumn" -> Json.obj(
           "id" -> 1, "ordering" -> 1,
           "kind" -> "text",
           "name" -> "Test Column 1",
           "multilanguage" -> false,
-          "identifier" -> true
+          "identifier" -> true,
+          "displayName" -> Json.obj(),
+          "description" -> Json.obj()
         ))))
 
     for {
@@ -149,13 +165,17 @@ class LinkTest extends TableauxTestBase {
         "kind" -> "link",
         "multilanguage" -> false,
         "identifier" -> false,
+        "displayName" -> Json.obj(),
+        "description" -> Json.obj(),
         "toTable" -> 2,
         "toColumn" -> Json.obj(
           "id" -> 1, "ordering" -> 1,
           "kind" -> "text",
           "name" -> "Test Column 1",
           "multilanguage" -> false,
-          "identifier" -> true
+          "identifier" -> true,
+          "displayName" -> Json.obj(),
+          "description" -> Json.obj()
         ))))
 
     for {

--- a/src/test/scala/com/campudus/tableaux/MediaTest.scala
+++ b/src/test/scala/com/campudus/tableaux/MediaTest.scala
@@ -14,7 +14,7 @@ import io.vertx.scala.FutureHelper._
 import io.vertx.scala.SQLConnection
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.vertx.scala.core.json.{Json, JsonArray}
+import org.vertx.scala.core.json.Json
 
 import scala.concurrent.{Future, Promise}
 import scala.reflect.io.Path
@@ -413,7 +413,9 @@ class MediaTest extends TableauxTestBase {
       "name" -> "Downloads",
       "kind" -> "attachment",
       "multilanguage" -> false,
-      "identifier" -> false)))
+      "identifier" -> false,
+      "displayName" -> Json.obj(),
+      "description" -> Json.obj())))
 
     val column = Json.obj("columns" -> Json.arr(Json.obj(
       "kind" -> "attachment",

--- a/src/test/scala/com/campudus/tableaux/MultiLanguageTest.scala
+++ b/src/test/scala/com/campudus/tableaux/MultiLanguageTest.scala
@@ -7,8 +7,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.vertx.scala.core.json.{Json, JsonObject}
 
-import scala.concurrent.Future
-
 @RunWith(classOf[VertxUnitRunner])
 class MultiLanguageTest extends TableauxTestBase {
 
@@ -21,7 +19,9 @@ class MultiLanguageTest extends TableauxTestBase {
       "kind" -> "text",
       "ordering" -> columnId,
       "multilanguage" -> true,
-      "identifier" -> true
+      "identifier" -> true,
+      "displayName" -> Json.obj(),
+      "description" -> Json.obj()
     )
 
     for {

--- a/src/test/scala/com/campudus/tableaux/controller/StructureControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/StructureControllerTest.scala
@@ -1,13 +1,12 @@
 package com.campudus.tableaux.controller
 
+import com.campudus.tableaux.TableauxTestBase
 import com.campudus.tableaux.database.domain.CreateSimpleColumn
 import com.campudus.tableaux.database.model.StructureModel
 import com.campudus.tableaux.database.{DatabaseConnection, SingleLanguage, TextType}
-import com.campudus.tableaux.{TableauxTestBase, Starter, TestConfig}
-import io.vertx.core.Vertx
 import io.vertx.ext.unit.TestContext
 import io.vertx.ext.unit.junit.VertxUnitRunner
-import io.vertx.scala.{SQLConnection, VertxExecutionContext}
+import io.vertx.scala.SQLConnection
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -33,7 +32,7 @@ class StructureControllerTest extends TableauxTestBase {
   @Test
   def checkCreateLinkColumnWithNullParameter(implicit c: TestContext): Unit = {
     val controller = createStructureController()
-    illegalArgumentTest(controller.createColumns(0, Seq(CreateSimpleColumn(null, null, null, SingleLanguage, identifier = false))))
+    illegalArgumentTest(controller.createColumns(0, Seq(CreateSimpleColumn(null, null, null, SingleLanguage, identifier = false, List()))))
   }
 
   @Test
@@ -45,13 +44,13 @@ class StructureControllerTest extends TableauxTestBase {
   @Test
   def checkCreateColumnWithNullName(implicit c: TestContext): Unit = {
     val controller = createStructureController()
-    illegalArgumentTest(controller.createColumns(0, Seq(CreateSimpleColumn(null, None, TextType, SingleLanguage, identifier = false))))
+    illegalArgumentTest(controller.createColumns(0, Seq(CreateSimpleColumn(null, None, TextType, SingleLanguage, identifier = false, List()))))
   }
 
   @Test
   def checkCreateColumnWithNullType(implicit c: TestContext): Unit = {
     val controller = createStructureController()
-    illegalArgumentTest(controller.createColumns(0, Seq(CreateSimpleColumn("", None, null, SingleLanguage, identifier = false))))
+    illegalArgumentTest(controller.createColumns(0, Seq(CreateSimpleColumn("", None, null, SingleLanguage, identifier = false, List()))))
   }
 
   @Test

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -62,8 +62,8 @@ class SystemControllerTest extends TableauxTestBase {
   def retrieveVersions(implicit c: TestContext): Unit = okTest {
     val expectedJson = Json.obj(
       "database" -> Json.obj(
-        "current" -> 6,
-        "specification" -> 6
+        "current" -> 7,
+        "specification" -> 7
       )
     )
 

--- a/src/test/scala/com/campudus/tableaux/displayInfoTests.scala
+++ b/src/test/scala/com/campudus/tableaux/displayInfoTests.scala
@@ -1,0 +1,193 @@
+package com.campudus.tableaux
+
+import com.campudus.tableaux.database.domain.{DescriptionOnly, DisplayInfos, NameAndDescription, NameOnly}
+import com.campudus.tableaux.database.model.TableauxModel.{ColumnId, TableId}
+import org.junit.Assert._
+import org.junit.Test
+import org.vertx.scala.core.json.Json
+
+abstract class AbstractDisplayInfosTest {
+
+  @Test
+  def checkSingleName(): Unit = {
+    val di = singleName(1, 1, "de_DE", "Spalte 1")
+    assertTrue(di.nonEmpty)
+    assertEquals(
+      s"""INSERT INTO system_columns_lang (table_id, column_id, langtag, name, description)
+          |VALUES (?, ?, ?, ?, ?)""".stripMargin, di.statement)
+    assertEquals(Seq(1, 1, "de_DE", "Spalte 1", null), di.binds)
+  }
+
+  @Test
+  def checkMultipleNames(): Unit = {
+    val di = multipleNames(1, 1, List("de_DE" -> "Spalte 1", "en_US" -> "Column 1"))
+    assertTrue(di.nonEmpty)
+    assertEquals(
+      s"""INSERT INTO system_columns_lang (table_id, column_id, langtag, name, description)
+          |VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""".stripMargin, di.statement)
+    assertEquals(Seq(1, 1, "de_DE", "Spalte 1", null, 1, 1, "en_US", "Column 1", null), di.binds)
+  }
+
+  @Test
+  def checkSingleDescription(): Unit = {
+    val di = singleDesc(1, 1, "de_DE", "Spalte 1 Beschreibung")
+    assertTrue(di.nonEmpty)
+    assertEquals(
+      s"""INSERT INTO system_columns_lang (table_id, column_id, langtag, name, description)
+          |VALUES (?, ?, ?, ?, ?)""".stripMargin, di.statement)
+    assertEquals(Seq(1, 1, "de_DE", null, "Spalte 1 Beschreibung"), di.binds)
+  }
+
+  @Test
+  def checkMultipleDescriptions(): Unit = {
+    val di = multipleDescs(1, 1, List("de_DE" -> "Spalte 1 Beschreibung", "en_US" -> "Column 1 Description"))
+    assertTrue(di.nonEmpty)
+    assertEquals(
+      s"""INSERT INTO system_columns_lang (table_id, column_id, langtag, name, description)
+          |VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""".stripMargin, di.statement)
+    assertEquals(Seq(1, 1, "de_DE", null, "Spalte 1 Beschreibung", 1, 1, "en_US", null, "Column 1 Description"), di.binds)
+  }
+
+  @Test
+  def checkSingleNameAndDescription(): Unit = {
+    val di = singleNameAndDesc(1, 1, "de_DE", "Spalte 1", "Spalte 1 Beschreibung")
+    assertTrue(di.nonEmpty)
+    assertEquals(
+      s"""INSERT INTO system_columns_lang (table_id, column_id, langtag, name, description)
+          |VALUES (?, ?, ?, ?, ?)""".stripMargin, di.statement)
+    assertEquals(Seq(1, 1, "de_DE", "Spalte 1", "Spalte 1 Beschreibung"), di.binds)
+  }
+
+  @Test
+  def checkMultipleNamesAndDescriptions(): Unit = {
+    val di = multipleNameAndDesc(1, 1, List(("de_DE", "Spalte 1", "Spalte 1 Beschreibung"),
+      ("en_US", "Column 1", "Column 1 Description")))
+    assertTrue(di.nonEmpty)
+    assertEquals(
+      s"""INSERT INTO system_columns_lang (table_id, column_id, langtag, name, description)
+          |VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""".stripMargin, di.statement)
+    assertEquals(Seq(1, 1, "de_DE", "Spalte 1", "Spalte 1 Beschreibung", 1, 1, "en_US", "Column 1", "Column 1 Description"), di.binds)
+  }
+
+  @Test
+  def checkNameAndOtherDesc(): Unit = {
+    val di = multipleNameAndDesc(1, 1, List(("de_DE", "Spalte 1", null), ("en_US", null, "Column 1 Description")))
+    assertTrue(di.nonEmpty)
+    assertEquals(
+      s"""INSERT INTO system_columns_lang (table_id, column_id, langtag, name, description)
+          |VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""".stripMargin, di.statement)
+    assertEquals(Seq(1, 1, "de_DE", "Spalte 1", null, 1, 1, "en_US", null, "Column 1 Description"), di.binds)
+  }
+
+  @Test
+  def checkCombinations(): Unit = {
+    val di = multipleNameAndDesc(1, 1, List(
+      ("de_DE", "Spalte 1", "Spalte 1 Beschreibung"),
+      ("en_US", null, "Column 1 Description"),
+      ("fr_FR", "Colonne 1", null)
+    ))
+    assertTrue(di.nonEmpty)
+    assertEquals(
+      s"""INSERT INTO system_columns_lang (table_id, column_id, langtag, name, description)
+          |VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)""".stripMargin, di.statement)
+    val all = Seq(
+      Seq(1, 1, "de_DE", "Spalte 1", "Spalte 1 Beschreibung"),
+      Seq(1, 1, "en_US", null, "Column 1 Description"),
+      Seq(1, 1, "fr_FR", "Colonne 1", null)
+    )
+
+    assertTrue(all.forall(s => di.binds.indexOfSlice(s) >= 0))
+  }
+
+  @Test
+  def emptyDisplayStuff(): Unit = {
+    val di = emptyDisplayInfo(1, 1)
+    assertFalse(di.nonEmpty)
+  }
+
+  def emptyDisplayInfo(tableId: TableId, columnId: ColumnId): DisplayInfos
+
+  def singleName(tableId: TableId, columnId: ColumnId, langtag: String, name: String): DisplayInfos
+
+  def multipleNames(tableId: TableId, columnId: ColumnId, langNames: List[(String, String)]): DisplayInfos
+
+  def singleDesc(tableId: TableId, columnId: ColumnId, langtag: String, desc: String): DisplayInfos
+
+  def multipleDescs(tableId: TableId, columnId: ColumnId, langDescs: List[(String, String)]): DisplayInfos
+
+  def singleNameAndDesc(tableId: TableId, columnId: ColumnId, langtag: String, name: String, desc: String): DisplayInfos
+
+  def multipleNameAndDesc(tableId: TableId, columnId: ColumnId, infos: List[(String, String, String)]): DisplayInfos
+
+}
+
+class DisplayInfoTestDirect extends AbstractDisplayInfosTest {
+
+  override def emptyDisplayInfo(tableId: TableId, columnId: ColumnId): DisplayInfos =
+    DisplayInfos(tableId, columnId, List())
+
+  override def singleName(tableId: TableId, columnId: ColumnId, langtag: String, name: String): DisplayInfos =
+    DisplayInfos(tableId, columnId, List(NameOnly(langtag, name)))
+
+  override def multipleNames(tableId: TableId, columnId: ColumnId, langNames: List[(String, String)]): DisplayInfos =
+    DisplayInfos(tableId, columnId, langNames.map(t => NameOnly(t._1, t._2)))
+
+  override def singleDesc(tableId: TableId, columnId: ColumnId, langtag: String, desc: String): DisplayInfos =
+    DisplayInfos(tableId, columnId, List(DescriptionOnly(langtag, desc)))
+
+  override def multipleDescs(tableId: TableId, columnId: ColumnId, langDescs: List[(String, String)]): DisplayInfos =
+    DisplayInfos(tableId, columnId, langDescs.map(t => DescriptionOnly(t._1, t._2)))
+
+  override def singleNameAndDesc(tableId: TableId, columnId: ColumnId, langtag: String, name: String, desc: String): DisplayInfos =
+    DisplayInfos(tableId, columnId, List(NameAndDescription(langtag, name, desc)))
+
+  override def multipleNameAndDesc(tableId: TableId, columnId: ColumnId, infos: List[(String, String, String)]): DisplayInfos =
+    DisplayInfos(tableId, columnId, infos.map {
+      case (lang, name, null) => NameOnly(lang, name)
+      case (lang, null, desc) => DescriptionOnly(lang, desc)
+      case (lang, name, desc) => NameAndDescription(lang, name, desc)
+    })
+
+}
+
+class DisplayInfoTestJsonObject extends AbstractDisplayInfosTest {
+
+  override def emptyDisplayInfo(tableId: TableId, columnId: ColumnId): DisplayInfos =
+    DisplayInfos(tableId, columnId, Json.obj())
+
+  override def singleName(tableId: TableId, columnId: ColumnId, langtag: String, name: String): DisplayInfos =
+    DisplayInfos(tableId, columnId, Json.obj("displayName" -> Json.obj(langtag -> name)))
+
+  override def multipleNames(tableId: TableId, columnId: ColumnId, langNames: List[(String, String)]): DisplayInfos = {
+    DisplayInfos(tableId, columnId, Json.obj("displayName" -> langNames.foldLeft(Json.obj()) {
+      case (json, (langtag, name)) => json.mergeIn(Json.obj(langtag -> name))
+    }))
+  }
+
+  override def singleDesc(tableId: TableId, columnId: ColumnId, langtag: String, desc: String): DisplayInfos =
+    DisplayInfos(tableId, columnId, Json.obj("description" -> Json.obj(langtag -> desc)))
+
+  override def multipleDescs(tableId: TableId, columnId: ColumnId, langDescs: List[(String, String)]): DisplayInfos =
+    DisplayInfos(tableId, columnId, Json.obj("description" -> langDescs.foldLeft(Json.obj()) {
+      case (json, (langtag, desc)) => json.mergeIn(Json.obj(langtag -> desc))
+    }))
+
+  override def singleNameAndDesc(tableId: TableId, columnId: ColumnId, langtag: String, name: String, desc: String): DisplayInfos =
+    DisplayInfos(tableId, columnId, Json.obj(
+      "displayName" -> Json.obj(langtag -> name),
+      "description" -> Json.obj(langtag -> desc)
+    ))
+
+  override def multipleNameAndDesc(tableId: TableId, columnId: ColumnId, infos: List[(String, String, String)]): DisplayInfos = {
+    val result = infos.foldLeft(Json.obj()) {
+      case (json, (lang, name, null)) => json.mergeIn(Json.obj("displayName" -> json.getJsonObject("displayName", Json.obj()).mergeIn(Json.obj(lang -> name))))
+      case (json, (lang, null, desc)) => json.mergeIn(Json.obj("description" -> json.getJsonObject("description", Json.obj()).mergeIn(Json.obj(lang -> desc))))
+      case (json, (lang, name, desc)) =>
+        val n = json.getJsonObject("displayName", Json.obj()).mergeIn(Json.obj(lang -> name))
+        val d = json.getJsonObject("description", Json.obj()).mergeIn(Json.obj(lang -> desc))
+        json.mergeIn(Json.obj("displayName" -> n)).mergeIn(Json.obj("description" -> d))
+    }
+    DisplayInfos(tableId, columnId, result)
+  }
+
+}

--- a/src/test/scala/com/campudus/tableaux/testtools/RequestCreation.scala
+++ b/src/test/scala/com/campudus/tableaux/testtools/RequestCreation.scala
@@ -7,6 +7,7 @@ object RequestCreation {
 
   sealed abstract class ColType(val kind: String) {
     val name: String
+
     def json: JsonObject = Json.obj("kind" -> kind, "name" -> name)
   }
 
@@ -16,11 +17,14 @@ object RequestCreation {
 
   case class Multilanguage(column: ColType) extends ColType(column.kind) {
     val name: String = column.name
+
     override def json: JsonObject = column.json.mergeIn(Json.obj("multilanguage" -> true))
   }
 
   case class Identifier(column: ColType) extends ColType(column.kind) {
     val name: String = column.name
+
     override def json: JsonObject = column.json.mergeIn(Json.obj("identifier" -> true))
   }
+
 }


### PR DESCRIPTION
This adds two multilanguage fields to columns: `displayName` and `description`.
I see some possibilities for refactoring:
* `ColumnType` could use a case class for all "standard fields", so we don't need to update the whole code base when adding some meta data to it.
* In our tests, we could use a quick `assertContains` like method that checks whether the standard other fields are set correctly instead of checking for all fields. Would be better than just check for a "recursive contains", I guess. But that may make sense as well.