### PR TITLE
Fix duplication error (+ some refactoring)

### DIFF
--- a/src/main/scala/com/campudus/tableaux/database/database.scala
+++ b/src/main/scala/com/campudus/tableaux/database/database.scala
@@ -209,7 +209,7 @@ class DatabaseConnection(val verticle: ScalaVerticle, val connection: SQLConnect
   }
 
   private def mapUpdateResult(msg: String, obj: JsonObject): JsonObject = {
-    import scala.collection.JavaConversions._
+    import scala.collection.JavaConverters._
 
     val updated = obj.getInteger("updated", 0)
     val keys = obj.getJsonArray("keys", Json.arr())
@@ -220,7 +220,7 @@ class DatabaseConnection(val verticle: ScalaVerticle, val connection: SQLConnect
       Json.arr()
     }
 
-    val results = new JsonArray(keys.getList.toList.map({ v: Any => Json.arr(v) }))
+    val results = Json.arr(keys.getList.asScala.map({ v: Any => Json.arr(v) }): _*)
 
     Json.obj(
       "status" -> "ok",

--- a/src/main/scala/com/campudus/tableaux/database/domain/domainobject.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/domainobject.scala
@@ -85,8 +85,8 @@ object MultiLanguageValue {
     * Generates MultiLanguageValue based on JSON
     */
   def apply[A](obj: JsonObject): MultiLanguageValue[A] = {
-    import scala.collection.JavaConversions._
-    val fields: Map[String, A] = obj.fieldNames().toList.map(name => name -> obj.getValue(name).asInstanceOf[A])(collection.breakOut)
+    import scala.collection.JavaConverters._
+    val fields: Map[String, A] = obj.fieldNames().asScala.map(name => name -> obj.getValue(name).asInstanceOf[A])(collection.breakOut)
 
     MultiLanguageValue[A](fields)
   }

--- a/src/main/scala/com/campudus/tableaux/database/model/AttachmentModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/AttachmentModel.scala
@@ -107,7 +107,7 @@ class AttachmentModel(protected[this] val connection: DatabaseConnection) extend
 
     for {
       result <- connection.query(select, Json.arr(tableId, columnId, rowId))
-      attachments <- Future(getSeqOfJsonArray(result).map(e => (e.get[String](0), e.get[Ordering](1))))
+      attachments <- Future(resultObjectToJsonArray(result).map(e => (e.get[String](0), e.get[Ordering](1))))
       files <- Future.sequence(attachments.map(attachment => retrieveFile(UUID.fromString(attachment._1), attachment._2)))
     } yield files
   }

--- a/src/main/scala/com/campudus/tableaux/database/model/FileModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/FileModel.scala
@@ -150,7 +150,7 @@ class FileModel(override protected[this] val connection: DatabaseConnection) ext
         connection.query(select("f.idfolder = ? AND f.tmp = FALSE"), Json.arr(folder.get))
       }
 
-      resultRows = getSeqOfJsonArray(resultJson)
+      resultRows = resultObjectToJsonArray(resultJson)
     } yield {
       resultRows.map(convertRowToFile)
     }
@@ -164,7 +164,7 @@ class FileModel(override protected[this] val connection: DatabaseConnection) ext
         connection.query(selectOrdered("f.idfolder = ? AND f.tmp = FALSE", sortByLangtag), Json.arr(folder.get))
       }
 
-      resultRows = getSeqOfJsonArray(resultJson)
+      resultRows = resultObjectToJsonArray(resultJson)
     } yield {
       resultRows.map(convertRowToFile)
     }

--- a/src/main/scala/com/campudus/tableaux/database/model/FolderModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/FolderModel.scala
@@ -95,7 +95,7 @@ class FolderModel(override protected[this] val connection: DatabaseConnection) e
 
     for {
       result <- connection.query(select)
-      resultArr <- Future(getSeqOfJsonArray(result))
+      resultArr <- Future(resultObjectToJsonArray(result))
     } yield {
       resultArr.map(convertJsonArrayToFolder)
     }
@@ -116,7 +116,7 @@ class FolderModel(override protected[this] val connection: DatabaseConnection) e
         case None => connection.query(select("idparent IS NULL"))
         case Some(id) => connection.query(select("idparent = ?"), Json.arr(id.toString))
       }
-      resultArr <- Future(getSeqOfJsonArray(result))
+      resultArr <- Future(resultObjectToJsonArray(result))
     } yield {
       resultArr.map(convertJsonArrayToFolder)
     }

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
@@ -183,7 +183,7 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
         json.map(selectNotNull(_).head)
       }
       resultLang <- connection.query(selectLang, Json.arr(table.id, columnId))
-      dis = getSeqOfJsonArray(resultLang).flatMap { arr =>
+      dis = resultObjectToJsonArray(resultLang).flatMap { arr =>
         val langtag = arr.getString(0)
         val name = arr.getString(1)
         val description = arr.getString(2)
@@ -244,7 +244,7 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
     for {
       result <- connection.query(select, Json.arr(table.id))
       mappedColumns <- {
-        val futures = getSeqOfJsonArray(result).map { arr =>
+        val futures = resultObjectToJsonArray(result).map { arr =>
           val columnId = arr.get[ColumnId](0)
           val columnName = arr.get[String](1)
           val kind = Mapper.getDatabaseType(arr.get[String](2))
@@ -259,7 +259,7 @@ class ColumnModel(val connection: DatabaseConnection) extends DatabaseQuery {
 
           for {
             result <- connection.query(selectLang, Json.arr(table.id, columnId))
-            dis = getSeqOfJsonArray(result).map { arr =>
+            dis = resultObjectToJsonArray(result).map { arr =>
               DisplayInfos.fromString(arr.getString(0), arr.getString(1), arr.getString(2))
             }
             res <- mapColumn(depth, table, columnId, columnName, kind, ordering, languageType, identifier, dis)

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
@@ -44,7 +44,7 @@ class TableModel(val connection: DatabaseConnection) extends DatabaseQuery {
     for {
       result <- connection.query("SELECT table_id, user_table_name, is_hidden FROM system_table ORDER BY ordering, table_id")
     } yield {
-      getSeqOfJsonArray(result).map { row =>
+      resultObjectToJsonArray(result).map { row =>
         Table(row.get[TableId](0), row.getString(1), row.getBoolean(2))
       }
     }

--- a/src/main/scala/com/campudus/tableaux/helper/ResultChecker.scala
+++ b/src/main/scala/com/campudus/tableaux/helper/ResultChecker.scala
@@ -9,13 +9,13 @@ import org.vertx.scala.core.json.{JsonArray, JsonObject}
  */
 object ResultChecker {
 
-  def getSeqOfJsonArray(json: JsonObject): Seq[JsonArray] = {
-    jsonArrayToSeq(json.getJsonArray("results"))
+  def resultObjectToJsonArray(json: JsonObject): Seq[JsonArray] = {
+    jsonArrayToSeq(json.getJsonArray("results")).map(_.asInstanceOf[JsonArray])
   }
 
-  def jsonArrayToSeq[A](json: JsonArray): Seq[A] = {
+  def jsonArrayToSeq(json: JsonArray): Seq[Any] = {
     import scala.collection.JavaConverters._
-    json.asScala.toSeq.asInstanceOf[Seq[A]]
+    json.asScala.toSeq.asInstanceOf[Seq[Any]]
   }
 
   def deleteNotNull(json: JsonObject): Seq[JsonArray] = checkNotNull(json, "delete")
@@ -32,7 +32,7 @@ object ResultChecker {
     if (json.getString("message") == message) {
       throw NotFoundInDatabaseException(s"Warning: $message query failed", queryType)
     } else {
-      getSeqOfJsonArray(json)
+      resultObjectToJsonArray(json)
     }
   }
 
@@ -44,7 +44,7 @@ object ResultChecker {
     if (json.getInteger("rows") != size) {
       throw DatabaseException(s"Error: query failed because result size (${json.getInteger("rows")}) doesn't match expected size ($size)", "checkSize")
     } else {
-      getSeqOfJsonArray(json)
+      resultObjectToJsonArray(json)
     }
   }
 }


### PR DESCRIPTION
Added test for row duplication with links on `ConcatColumns` as it broke.

Refactorings:
* Use Converters instead of Conversions to make conversions more explicit
* Rename getSeqOfJsonArray -> resultObjectToJsonArray
* Results did not necessarily yield AnyRefs -> changed to Any type

It also did not look like removing `.map(_.asJava)` broke anything. Therefore this is kicked. Maybe needed for filter api? It broke another test after changing `AnyRef` to `Any`.