### PR TITLE
Settings table & Boolean default values

### DIFF
--- a/src/main/resources/schema/schema_v13.sql
+++ b/src/main/resources/schema/schema_v13.sql
@@ -1,0 +1,2 @@
+ALTER TABLE system_table ADD COLUMN type TEXT;
+UPDATE system_table SET type = 'generic';

--- a/src/main/resources/schema/schema_v14.sql
+++ b/src/main/resources/schema/schema_v14.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE FUNCTION set_null_boolean_to_false(tablename TEXT, columnname TEXT)
+  RETURNS TEXT AS $$
+BEGIN
+  EXECUTE 'UPDATE ' || tablename || ' SET ' || columnname || ' = FALSE WHERE ' || columnname || ' IS NULL;';
+  EXECUTE 'ALTER TABLE ' || tablename || ' ALTER COLUMN ' || columnname || ' SET DEFAULT FALSE';
+
+  RETURN tablename || ' ' || columnname :: TEXT;
+END
+$$ LANGUAGE plpgsql;
+
+SELECT set_null_boolean_to_false(sub.tablename, sub.columnname)
+FROM
+  (
+    SELECT
+      CASE
+      WHEN multilanguage IS NULL
+        THEN 'user_table_' || table_id
+      WHEN multilanguage IS NOT NULL
+        THEN 'user_table_lang_' || table_id
+      END                    AS tablename,
+      'column_' || column_id AS columnname
+    FROM system_columns
+    WHERE column_type = 'boolean'
+  ) AS sub;
+
+DROP FUNCTION set_null_boolean_to_false( TEXT, TEXT );

--- a/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
@@ -124,7 +124,7 @@ class SystemController(override val config: TableauxConfig,
     logger.info(s"createTable $tableName columns $rows")
 
     for {
-      table <- structureModel.tableStruc.create(tableName, hidden = false, None, List())
+      table <- structureModel.tableStruc.create(tableName, hidden = false, None, List(), GenericTable)
       columns <- structureModel.columnStruc.createColumns(table, columns)
 
       columnIds = columns.map(_.id)

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -130,7 +130,8 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
     setupVersion(readSchemaFile("schema_v10"), 10),
     setupVersion(readSchemaFile("schema_v11"), 11),
     setupVersion(readSchemaFile("schema_v12"), 12),
-    setupVersion(readSchemaFile("schema_v13"), 13)
+    setupVersion(readSchemaFile("schema_v13"), 13),
+    setupVersion(readSchemaFile("schema_v14"), 14)
   )
 
   private def readSchemaFile(name: String): String = {

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -129,7 +129,8 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
     setupVersion(readSchemaFile("schema_v9"), 9),
     setupVersion(readSchemaFile("schema_v10"), 10),
     setupVersion(readSchemaFile("schema_v11"), 11),
-    setupVersion(readSchemaFile("schema_v12"), 12)
+    setupVersion(readSchemaFile("schema_v12"), 12),
+    setupVersion(readSchemaFile("schema_v13"), 13)
   )
 
   private def readSchemaFile(name: String): String = {

--- a/src/main/scala/com/campudus/tableaux/exceptions.scala
+++ b/src/main/scala/com/campudus/tableaux/exceptions.scala
@@ -81,3 +81,8 @@ case class WrongColumnKindException[T <: ColumnType[_]](column: ColumnType[_], s
   override val statusCode: Int = 400
   override val message: String = s"This action is not possible on ${column.name}. Action only available for columns of kind ${shouldBe.toString}."
 }
+
+case class ForbiddenException(override val message: String, subId: String) extends CustomException {
+  override val id: String = s"error.request.forbidden.$subId"
+  override val statusCode: Int = 403
+}

--- a/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
+++ b/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
@@ -146,20 +146,11 @@ object JsonUtils extends LazyLogging {
     val displayNames = Try(checkForAllValues[String](json.getJsonObject("displayName"), n => n == null || n.isInstanceOf[String], "displayName").get).toOption
     val descriptions = Try(checkForAllValues[String](json.getJsonObject("description"), d => d == null || d.isInstanceOf[String], "description").get).toOption
 
-    val countryCodes = ifContainsDo(json, "countryCodes", {
-      json =>
-        checkAllValuesOfArray[String](json.getJsonArray("countryCodes"), d => d.isInstanceOf[String] && d.matches("[A-Z]{2,3}"), "countryCodes").get
+    val countryCodes = booleanToValueOption(json.containsKey("countryCodes"), {
+      checkAllValuesOfArray[String](json.getJsonArray("countryCodes"), d => d.isInstanceOf[String] && d.matches("[A-Z]{2,3}"), "countryCodes").get
     }).map(_.asScala.toSeq.map({ case code: String => code }))
 
     (name, ord, kind, identifier, displayNames, descriptions, countryCodes)
-  }
-
-  def ifContainsDo[A](json: JsonObject, field: String, fn: JsonObject => A): Option[A] = {
-    if (json.containsKey(field)) {
-      Some(fn(json))
-    } else {
-      None
-    }
   }
 
   def booleanToValueOption[A](boolean: Boolean, value: => A): Option[A] = {

--- a/src/main/scala/com/campudus/tableaux/router/BaseRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/BaseRouter.scala
@@ -56,6 +56,8 @@ trait BaseRouter extends Router with VertxAccess with LazyLogging {
       reply =>
         Header("Expires", "-1", Header("Cache-Control", "no-cache", reply))
     }).recover({
+      case ex: InvalidNonceException => Error(RouterException(ex.message, null, ex.id, ex.statusCode))
+      case ex: NoNonceException => Error(RouterException(ex.message, null, ex.id, ex.statusCode))
       case ex: CustomException => Error(ex.toRouterException)
       case ex: IllegalArgumentException => Error(RouterException(ex.getMessage, ex, "error.arguments", 422))
       case ex: Throwable => Error(RouterException("unknown error", ex, "error.unknown", 500))

--- a/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
@@ -2,7 +2,7 @@ package com.campudus.tableaux.router
 
 import com.campudus.tableaux.TableauxConfig
 import com.campudus.tableaux.controller.StructureController
-import com.campudus.tableaux.database.domain.DisplayInfos
+import com.campudus.tableaux.database.domain.{DisplayInfos, GenericTable, TableType}
 import com.campudus.tableaux.helper.JsonUtils._
 import io.vertx.ext.web.RoutingContext
 import org.vertx.scala.router.routing._
@@ -65,6 +65,7 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
         name = json.getString("name")
         hidden = json.getBoolean("hidden", false).booleanValue()
         displayInfos = DisplayInfos.allInfos(json)
+        tableType = TableType(json.getString("type", GenericTable.NAME))
 
         // if contains than user wants langtags to be set
         // but then langtags could be null so that's the second option
@@ -78,7 +79,7 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
         // {langtags:['de-DE']} => Some(Seq('de-DE')) => db: ['de-DE']
         langtags = booleanToValueOption(json.containsKey("langtags"), Option(json.getJsonArray("langtags")).map(_.asScala.map(_.toString).toSeq))
 
-        created <- controller.createTable(name, hidden, langtags, displayInfos)
+        created <- controller.createTable(name, hidden, langtags, displayInfos, tableType)
       } yield created
     }
 

--- a/src/test/scala/com/campudus/tableaux/api/content/LinkTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/LinkTest.scala
@@ -626,6 +626,16 @@ class LinkTest extends LinkTestBase {
   }
 
   @Test
+  def tryToDeleteLinkValueOfInvalidColumnType(implicit c: TestContext): Unit = exceptionTest("error.request.column.wrongtype") {
+    for {
+      (tableId1, _) <- setupTwoTables()
+
+      //try to remove link
+      _ <- sendRequest("DELETE", s"/tables/$tableId1/columns/1/rows/1/link/2")
+    } yield ()
+  }
+
+  @Test
   def putLinkValuesInDifferentWays(implicit c: TestContext): Unit = okTest {
     val oneValue = Json.obj("value" -> 1)
     val objOneValue = Json.obj("value" -> Json.obj("to" -> 2))

--- a/src/test/scala/com/campudus/tableaux/api/content/MultiLanguageTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/MultiLanguageTest.scala
@@ -217,7 +217,7 @@ class MultiLanguageTest extends TableauxTestBase {
          | "id" : $rowId,
          | "values" : [
          |  {"de_DE" : "Hallo, Welt!", "en_US" : "Hello, World!"},
-         |  {},
+         |  {"de_DE" : false, "en_US" : false},
          |  {},
          |  {},
          |  {},
@@ -297,7 +297,7 @@ class MultiLanguageTest extends TableauxTestBase {
         |  "id" : 1,
         |  "values" : [
         |   { "de_DE" : "Hallo, Welt!", "en_US" : "Hello, Cell!" },
-        |   { "de_DE" : true },
+        |   { "de_DE" : true, "en_US" : false },
         |   { "de_DE" : 3.1415926 },
         |   { "en_US" : "Hello, Cell!" },
         |   { "en_US" : "Hello, Cell!" },

--- a/src/test/scala/com/campudus/tableaux/api/content/RetrieveTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/RetrieveTest.scala
@@ -95,7 +95,7 @@ class RetrieveTest extends TableauxTestBase {
         "totalSize" -> 1
       ),
       "rows" -> Json.arr(
-        Json.obj("id" -> 1, "values" -> Json.arr(null, null, null))),
+        Json.obj("id" -> 1, "values" -> Json.arr(null, null, false))),
       "langtags" -> Json.arr("de-DE", "en-GB")
     )
 

--- a/src/test/scala/com/campudus/tableaux/api/structure/ColumnLanguageTypeTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/ColumnLanguageTypeTest.scala
@@ -69,7 +69,7 @@ class ColumnLanguageTypeTest extends TableauxTestBase {
     val columnWithInvalidLanguageType = Json.obj(
       "name" -> "column1",
       "kind" -> "shorttext",
-      "multilanguage" -> "false"
+      "multilanguage" -> false
     )
 
     val postColumn1 = Json.obj("columns" -> Json.arr(columnWithInvalidLanguageType))

--- a/src/test/scala/com/campudus/tableaux/api/structure/SettingsTableTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/SettingsTableTest.scala
@@ -42,6 +42,13 @@ class SettingsTableTest extends TableauxTestBase {
   }
 
   @Test
+  def createTableWithInvalidTableType(implicit c: TestContext): Unit = exceptionTest("error.arguments") {
+    for {
+      result <- sendRequest("POST", "/tables", Json.obj("name" -> "settings", "type" -> "sgnittes", "displayName" -> Json.obj("de" -> "Settings Table")))
+    } yield ()
+  }
+
+  @Test
   def addColumnToSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.column") {
     for {
       tableId <- createSettingsTable()

--- a/src/test/scala/com/campudus/tableaux/api/structure/SettingsTableTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/SettingsTableTest.scala
@@ -69,13 +69,35 @@ class SettingsTableTest extends TableauxTestBase {
   }
 
   @Test
-  def changeKeyCellOfSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.cell") {
+  def updateKeyCellOfSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.cell") {
     for {
       tableId <- createSettingsTable()
 
       _ <- sendRequest("POST", s"/tables/$tableId/rows")
 
       _ <- sendRequest("POST", s"/tables/$tableId/columns/1/rows/1", Json.obj("value" -> "another value"))
+    } yield ()
+  }
+
+  @Test
+  def replaceKeyCellOfSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.cell") {
+    for {
+      tableId <- createSettingsTable()
+
+      _ <- sendRequest("POST", s"/tables/$tableId/rows")
+
+      _ <- sendRequest("PUT", s"/tables/$tableId/columns/1/rows/1", Json.obj("value" -> "another value"))
+    } yield ()
+  }
+
+  @Test
+  def clearKeyCellOfSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.cell") {
+    for {
+      tableId <- createSettingsTable()
+
+      _ <- sendRequest("POST", s"/tables/$tableId/rows")
+
+      _ <- sendRequest("DELETE", s"/tables/$tableId/columns/1/rows/1")
     } yield ()
   }
 

--- a/src/test/scala/com/campudus/tableaux/api/structure/SettingsTableTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/SettingsTableTest.scala
@@ -1,0 +1,103 @@
+package com.campudus.tableaux.api.structure
+
+import com.campudus.tableaux.database.model.TableauxModel.TableId
+import com.campudus.tableaux.testtools.TableauxTestBase
+import io.vertx.ext.unit.TestContext
+import io.vertx.ext.unit.junit.VertxUnitRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.vertx.scala.core.json.Json
+
+import scala.concurrent.Future
+
+@RunWith(classOf[VertxUnitRunner])
+class SettingsTableTest extends TableauxTestBase {
+
+  private def createSettingsTable(): Future[TableId] = {
+    for {
+      result <- sendRequest("POST", "/tables", Json.obj("name" -> "settings", "type" -> "settings", "displayName" -> Json.obj("de" -> "Settings Table")))
+    } yield result.getLong("id")
+  }
+
+  @Test
+  def createSettingsTable(implicit c: TestContext): Unit = okTest {
+    for {
+      tableId <- createSettingsTable()
+      settingsTable <- sendRequest("GET", s"/completetable/$tableId")
+    } yield {
+      val expectedSettingsTable = Json.obj(
+        "name" -> "settings",
+        "type" -> "settings",
+        "displayName" -> Json.obj("de" -> "Settings Table"),
+        "columns" -> Json.arr(
+          Json.obj("name" -> "key", "kind" -> "shorttext"),
+          Json.obj("name" -> "displayKey", "kind" -> "shorttext"),
+          Json.obj("name" -> "value", "kind" -> "text")
+        ),
+        "rows" -> Json.emptyArr()
+      )
+
+      assertContainsDeep(expectedSettingsTable, settingsTable)
+    }
+  }
+
+  @Test
+  def addColumnToSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- createSettingsTable()
+
+      _ <- sendRequest("POST", s"/tables/$tableId/columns", Json.obj("columns" -> Json.arr(Json.obj("name" -> "test", "kind" -> "text"))))
+    } yield ()
+  }
+
+  @Test
+  def changeColumnOfSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- createSettingsTable()
+
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/1", Json.obj("name" -> "test"))
+    } yield ()
+  }
+
+  @Test
+  def deleteColumnOfSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- createSettingsTable()
+
+      _ <- sendRequest("DELETE", s"/tables/$tableId/columns/1")
+    } yield ()
+  }
+
+  @Test
+  def changeKeyCellOfSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.cell") {
+    for {
+      tableId <- createSettingsTable()
+
+      _ <- sendRequest("POST", s"/tables/$tableId/rows")
+
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/1/rows/1", Json.obj("value" -> "another value"))
+    } yield ()
+  }
+
+  @Test
+  def changeDisplayKeyCellOfSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.cell") {
+    for {
+      tableId <- createSettingsTable()
+
+      _ <- sendRequest("POST", s"/tables/$tableId/rows")
+
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/2/rows/1", Json.obj("value" -> "another value"))
+    } yield ()
+  }
+
+  @Test
+  def deleteRowOfSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.row") {
+    for {
+      tableId <- createSettingsTable()
+
+      _ <- sendRequest("POST", s"/tables/$tableId/rows")
+
+      _ <- sendRequest("DELETE", s"/tables/$tableId/rows/1")
+    } yield ()
+  }
+}

--- a/src/test/scala/com/campudus/tableaux/controller/StructureControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/StructureControllerTest.scala
@@ -1,6 +1,6 @@
 package com.campudus.tableaux.controller
 
-import com.campudus.tableaux.database.domain.CreateSimpleColumn
+import com.campudus.tableaux.database.domain.{CreateSimpleColumn, GenericTable}
 import com.campudus.tableaux.database.model.StructureModel
 import com.campudus.tableaux.database.{DatabaseConnection, LanguageNeutral, TextType}
 import com.campudus.tableaux.testtools.TableauxTestBase
@@ -26,7 +26,7 @@ class StructureControllerTest extends TableauxTestBase {
   @Test
   def checkCreateTableWithNullParameter(implicit c: TestContext): Unit = {
     val controller = createStructureController()
-    illegalArgumentTest(controller.createTable(null, hidden = false, langtags = None, displayInfos = null))
+    illegalArgumentTest(controller.createTable(null, hidden = false, langtags = None, displayInfos = null, tableType = GenericTable))
   }
 
   @Test

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -68,8 +68,8 @@ class SystemControllerTest extends TableauxTestBase {
   def retrieveVersions(implicit c: TestContext): Unit = okTest {
     val expectedJson = Json.obj(
       "database" -> Json.obj(
-        "current" -> 12,
-        "specification" -> 12
+        "current" -> 13,
+        "specification" -> 13
       )
     )
 

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -68,8 +68,8 @@ class SystemControllerTest extends TableauxTestBase {
   def retrieveVersions(implicit c: TestContext): Unit = okTest {
     val expectedJson = Json.obj(
       "database" -> Json.obj(
-        "current" -> 13,
-        "specification" -> 13
+        "current" -> 14,
+        "specification" -> 14
       )
     )
 

--- a/src/test/scala/com/campudus/tableaux/testtools/TableauxTestBase.scala
+++ b/src/test/scala/com/campudus/tableaux/testtools/TableauxTestBase.scala
@@ -48,6 +48,31 @@ trait TestAssertionHelper {
     c
   }
 
+  def assertContainsDeep(expected: JsonObject, actual: JsonObject)(implicit c: TestContext): TestContext = {
+    import scala.collection.JavaConverters._
+    expected
+      .fieldNames()
+      .asScala
+      .map({
+        key =>
+          (expected.getValue(key), actual.getValue(key)) match {
+            case (expectedObj: JsonObject, actualObj: JsonObject) =>
+              assertContainsDeep(expectedObj, actualObj)
+            case (expectedArr: JsonArray, actualArr: JsonArray) =>
+              expectedArr.asScala.zip(actualArr.asScala)
+                .map({
+                  case (expectedObj: JsonObject, actualObj: JsonObject) =>
+                    assertContainsDeep(expectedObj, actualObj)
+                  case (expectedVal, actualVal) =>
+                    c.assertEquals(expectedVal, actualVal)
+                })
+            case (expectedVal, actualVal) =>
+              c.assertEquals(expectedVal, actualVal)
+          }
+      })
+    c
+  }
+
   def assertNull(excepted: Any)(implicit c: TestContext): TestContext = {
     c.assertNull(excepted)
   }


### PR DESCRIPTION
**Settings table**
- [x] New field 'type' on table. Valid options 'settings' or 'generic'.
- [x] Test create settings table check for three columns (key, displayKey, value)
- [x] Test forbidden action: add column
- [x] Test forbidden action: change column
- [x] Test forbidden action: change cell value of key or displayKey column
- [x] Test forbidden action: delete row

**Boolean default value**
- [x] 	Boolean value are now by default false and not null

**Others**
- [x] Don't print stacktrace on nonce exceptions
- [x] Add test which adds a language neutral column the "old" way
- [x] Add test which tries to delete link from a non-link column
- [x] Add test which tries to create a table with an invalid table type