### PR TITLE
Endpoint for column values

### DIFF
--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -648,4 +648,15 @@ class TableauxModel(
         } yield list ++ List(Row(table, rowId, rowLevelFlags, cellLevelFlags, columnsWithPostProcessedValues))
     }
   }
+
+  def retrieveColumnValues(table: Table, columnId: ColumnId, langtagOpt: Option[String]): Future[Seq[String]] = {
+    for {
+      shortTextColumn <- retrieveColumn(table, columnId).flatMap({
+        case shortTextColumn: ShortTextColumn => Future.successful(shortTextColumn)
+        case column => Future.failed(WrongColumnKindException(column, classOf[ShortTextColumn]))
+      })
+
+      values <- retrieveRowModel.retrieveColumnValues(shortTextColumn, langtagOpt)
+    } yield values
+  }
 }

--- a/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
@@ -25,6 +25,9 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
   private val LinkOfCell: Regex = s"/tables/(\\d+)/columns/(\\d+)/rows/(\\d+)/link/(\\d+)".r
   private val LinkOrderOfCell: Regex = s"/tables/(\\d+)/columns/(\\d+)/rows/(\\d+)/link/(\\d+)/order".r
 
+  private val ColumnsValues: Regex = "/tables/(\\d+)/columns/(\\d+)/values".r
+  private val ColumnsValuesWithLangtag: Regex = s"/tables/(\\d+)/columns/(\\d+)/values/($langtagRegex)".r
+
   private val Cell: Regex = "/tables/(\\d+)/columns/(\\d+)/rows/(\\d+)".r
   private val CellAnnotations: Regex = "/tables/(\\d+)/columns/(\\d+)/rows/(\\d+)/annotations".r
   private val CellAnnotation: Regex = s"/tables/(\\d+)/columns/(\\d+)/rows/(\\d+)/annotations/($uuidRegex)".r
@@ -312,6 +315,22 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
     case Delete(LinkOfCell(tableId, columnId, rowId, toId)) =>
       asyncGetReply {
         controller.deleteLink(tableId.toLong, columnId.toLong, rowId.toLong, toId.toLong)
+      }
+
+    /**
+      * Retrieve unique values of a shorttext column
+      */
+    case Get(ColumnsValues(tableId, columnId)) =>
+      asyncGetReply {
+        controller.retrieveColumnValues(tableId.toLong, columnId.toLong, None)
+      }
+
+    /**
+      * Retrieve unique values of a multi-language shorttext column
+      */
+    case Get(ColumnsValuesWithLangtag(tableId, columnId, langtag)) =>
+      asyncGetReply {
+        controller.retrieveColumnValues(tableId.toLong, columnId.toLong, Some(langtag))
       }
   }
 }

--- a/src/test/scala/com/campudus/tableaux/api/content/ColumnValuesTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/ColumnValuesTest.scala
@@ -124,23 +124,23 @@ class ColumnValuesTest extends TableauxTestBase {
       _ <- sendRequest("POST", s"/tables/$tableId/columns", Columns(createBooleanColumnJson))
         .map(_.getJsonArray("columns"))
 
-      _ <- sendRequest("GET", s"/tables/$tableId/columns/1/values/de") // should fail b/c multi-country is not allowed
-        .flatMap(_ => Future.failed(new Exception("this request should fail")))
+      _ <- sendRequest("GET", s"/tables/$tableId/columns/1/values/de")
+        .flatMap(_ => Future.failed(new Exception("request should fail b/c multi-country is not allowed")))
         .recoverWith({
           case TestCustomException(_, _, 422) => Future.successful(())
         })
-      _ <- sendRequest("GET", s"/tables/$tableId/columns/2/values/de") // should fail b/c shouldn't be called with langtag
-        .flatMap(_ => Future.failed(new Exception("this request should fail")))
+      _ <- sendRequest("GET", s"/tables/$tableId/columns/2/values/de")
+        .flatMap(_ => Future.failed(new Exception("request should fail b/c shouldn't be called with langtag")))
         .recoverWith({
           case TestCustomException(_, _, 422) => Future.successful(())
         })
-      _ <- sendRequest("GET", s"/tables/$tableId/columns/3/values") // should fail b/c numeric is not allowed
-        .flatMap(_ => Future.failed(new Exception("this request should fail")))
+      _ <- sendRequest("GET", s"/tables/$tableId/columns/3/values")
+        .flatMap(_ => Future.failed(new Exception("request should fail b/c numeric is not allowed")))
         .recoverWith({
           case TestCustomException(_, _, 400) => Future.successful(())
         })
-      _ <- sendRequest("GET", s"/tables/$tableId/columns/4/values") // should fail b/c boolean is not allowed
-        .flatMap(_ => Future.failed(new Exception("this request should fail")))
+      _ <- sendRequest("GET", s"/tables/$tableId/columns/4/values")
+        .flatMap(_ => Future.failed(new Exception("request should fail b/c boolean is not allowed")))
         .recoverWith({
           case TestCustomException(_, _, 400) => Future.successful(())
         })

--- a/src/test/scala/com/campudus/tableaux/api/content/ColumnValuesTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/ColumnValuesTest.scala
@@ -1,0 +1,149 @@
+package com.campudus.tableaux.api.content
+
+import com.campudus.tableaux.testtools.RequestCreation._
+import com.campudus.tableaux.testtools.{TableauxTestBase, TestCustomException}
+import io.vertx.ext.unit.TestContext
+import io.vertx.ext.unit.junit.VertxUnitRunner
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.vertx.scala.core.json.Json
+
+import scala.concurrent.Future
+
+@RunWith(classOf[VertxUnitRunner])
+class ColumnValuesTest extends TableauxTestBase {
+
+  @Test
+  def retrieveColumnValuesFromLanguageNeutralColumn(implicit c: TestContext): Unit = okTest {
+    val createStringColumnJson =
+      Json.obj("columns" -> Json.arr(Json.obj("kind" -> "shorttext", "name" -> "column", "identifier" -> true)))
+
+    val expectedJson = Json.obj(
+      "status" -> "ok",
+      "values" -> Json.arr(
+        "a",
+        "b",
+        "c"
+      )
+    )
+
+    for {
+      // prepare table
+      tableId <- sendRequest("POST", "/tables", Json.obj("name" -> "test")).map(_.getLong("id"))
+      columns <- sendRequest("POST", s"/tables/$tableId/columns", createStringColumnJson).map(_.getJsonArray("columns"))
+
+      // add rows
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> "a")))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> "c")))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> "b")))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> "a")))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> "b")))
+
+      // add some empty values
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> " ")))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> " ")))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> "")))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows")
+
+      test <- sendRequest("GET", s"/tables/$tableId/columns/1/values")
+    } yield {
+      assertEquals(expectedJson, test)
+    }
+  }
+
+  @Test
+  def retrieveColumnValuesFromMultiLanguageColumn(implicit c: TestContext): Unit = okTest {
+    val createStringColumnJson =
+      Json.obj(
+        "columns" -> Json.arr(
+          Json.obj("kind" -> "shorttext", "name" -> "column", "identifier" -> true, "languageType" -> "language")))
+
+    val expectedJson1 = Json.obj(
+      "status" -> "ok",
+      "values" -> Json.arr(
+        "a",
+        "b",
+        "c"
+      )
+    )
+
+    val expectedJson2 = Json.obj(
+      "status" -> "ok",
+      "values" -> Json.arr(
+        "a",
+        "d"
+      )
+    )
+
+    for {
+      // prepare table
+      tableId <- sendRequest("POST", "/tables", Json.obj("name" -> "test")).map(_.getLong("id"))
+      columns <- sendRequest("POST", s"/tables/$tableId/columns", createStringColumnJson).map(_.getJsonArray("columns"))
+
+      // add rows
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("de" -> "a"))))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("en" -> "a"))))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("de" -> "c"))))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("de" -> "b"))))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("de" -> "a"))))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("de" -> "b"))))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("en" -> "d"))))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("en" -> "a"))))
+
+      // add some empty values
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("de" -> " "))))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("de" -> " "))))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("de" -> ""))))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows", Rows(columns, Json.obj("column" -> Json.obj("en" -> ""))))
+      _ <- sendRequest("POST", s"/tables/$tableId/rows")
+
+      test1 <- sendRequest("GET", s"/tables/$tableId/columns/1/values/de")
+      test2 <- sendRequest("GET", s"/tables/$tableId/columns/1/values/en")
+    } yield {
+      assertEquals(expectedJson1, test1)
+      assertEquals(expectedJson2, test2)
+    }
+  }
+
+  @Test
+  def retrieveColumnValuesFromUnsupportedColumns(implicit c: TestContext): Unit = okTest {
+    val createShortTextCountryColumnJson = MultiCountry(ShortTextCol("column1"), Seq("DE"))
+    val createShortTextColumnJson = ShortTextCol("column2")
+    val createNumericColumnJson = NumericCol("column3")
+    val createBooleanColumnJson = BooleanCol("column4")
+
+    for {
+      // prepare table
+      tableId <- sendRequest("POST", "/tables", Json.obj("name" -> "test")).map(_.getLong("id"))
+      _ <- sendRequest("POST", s"/tables/$tableId/columns", Columns(createShortTextCountryColumnJson))
+        .map(_.getJsonArray("columns"))
+      _ <- sendRequest("POST", s"/tables/$tableId/columns", Columns(createShortTextColumnJson))
+        .map(_.getJsonArray("columns"))
+      _ <- sendRequest("POST", s"/tables/$tableId/columns", Columns(createNumericColumnJson))
+        .map(_.getJsonArray("columns"))
+      _ <- sendRequest("POST", s"/tables/$tableId/columns", Columns(createBooleanColumnJson))
+        .map(_.getJsonArray("columns"))
+
+      _ <- sendRequest("GET", s"/tables/$tableId/columns/1/values/de") // should fail b/c multi-country is not allowed
+        .flatMap(_ => Future.failed(new Exception("this request should fail")))
+        .recoverWith({
+          case TestCustomException(_, _, 422) => Future.successful(())
+        })
+      _ <- sendRequest("GET", s"/tables/$tableId/columns/2/values/de") // should fail b/c shouldn't be called with langtag
+        .flatMap(_ => Future.failed(new Exception("this request should fail")))
+        .recoverWith({
+          case TestCustomException(_, _, 422) => Future.successful(())
+        })
+      _ <- sendRequest("GET", s"/tables/$tableId/columns/3/values") // should fail b/c numeric is not allowed
+        .flatMap(_ => Future.failed(new Exception("this request should fail")))
+        .recoverWith({
+          case TestCustomException(_, _, 400) => Future.successful(())
+        })
+      _ <- sendRequest("GET", s"/tables/$tableId/columns/4/values") // should fail b/c boolean is not allowed
+        .flatMap(_ => Future.failed(new Exception("this request should fail")))
+        .recoverWith({
+          case TestCustomException(_, _, 400) => Future.successful(())
+        })
+    } yield ()
+  }
+}


### PR DESCRIPTION
This PR adds the functionally to retrieve all unique values of a shorttext column sorted by alphabet. It is only available for shorttext columns with languageType multi-language or language-neutral.

- `/tables/1/columns/1/values[/de]`
