### PR TITLE
Delete annotations on column delete

### DIFF
--- a/src/main/resources/schema/schema_v21.sql
+++ b/src/main/resources/schema/schema_v21.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE FUNCTION remove_dead_annotations(tableid BIGINT)
+  RETURNS TEXT AS $$
+BEGIN
+
+  EXECUTE 'DELETE FROM user_table_annotations_' || tableid || ' u WHERE NOT EXISTS (SELECT 1 FROM system_columns c WHERE c.table_id = ' || tableid || ' AND u.column_id = c.column_id)';
+
+  RETURN 'user_table_' || tableid :: TEXT;
+
+END
+$$
+LANGUAGE plpgsql;
+
+SELECT remove_dead_annotations(table_id)
+FROM system_table;
+
+DROP FUNCTION remove_dead_annotations( BIGINT );

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -142,7 +142,8 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
     setupVersion(readSchemaFile("schema_v17"), 17),
     setupVersion(readSchemaFile("schema_v18"), 18),
     setupVersion(readSchemaFile("schema_v19"), 19),
-    setupVersion(readSchemaFile("schema_v20"), 20)
+    setupVersion(readSchemaFile("schema_v20"), 20),
+    setupVersion(readSchemaFile("schema_v21"), 21)
   )
 
   private def readSchemaFile(name: String): String = {

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -69,8 +69,8 @@ class SystemControllerTest extends TableauxTestBase {
     okTest {
       val expectedJson = Json.obj(
         "database" -> Json.obj(
-          "current" -> 20,
-          "specification" -> 20
+          "current" -> 21,
+          "specification" -> 21
         )
       )
 


### PR DESCRIPTION
Plain database foreign key constraint with delete cascaded didn't work because we support annotation on the virtual concat column. There is no reference of concat column in `system_columns`. Had to add a manual annotation delete step if a column is going to be deleted.

- [x] delete existing zombie annotations
- [x] delete annotations on column delete