### PR TITLE
fixed error when deleting a table with one column

### DIFF
--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -177,7 +177,7 @@ class StructureController(override val config: TableauxConfig, override protecte
         case (future, column: LinkColumn) =>
           future.flatMap(_ => columnStruc.deleteLinkBothDirections(table, column.id))
         case (future, column: AttachmentColumn) =>
-          future.flatMap(_ => columnStruc.delete(table, column.id))
+          future.flatMap(_ => columnStruc.delete(table, column.id, bothDirections = false, checkForLastColumn = false))
         case (future, _) =>
           future.flatMap(_ => Future.successful(()))
       }

--- a/src/test/scala/com/campudus/tableaux/api/structure/DeleteStructureTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/DeleteStructureTest.scala
@@ -159,6 +159,54 @@ class DeleteStructureTest extends TableauxTestBase {
   }
 
   @Test
+  def deleteTableWithOneLinkColumn(implicit c: TestContext): Unit = okTest {
+    val createLinkColumnJson = Json.obj(
+      "columns" -> Json.arr(
+        Json.obj(
+          "name" -> "Test Link 1",
+          "kind" -> "link",
+          "toTable" -> 2
+        )
+      )
+    )
+
+    for {
+      table1 <- sendRequest("POST", "/tables", createTableJson).map(_.getLong("id"))
+      table2 <- sendRequest("POST", "/tables", createTableJson).map(_.getLong("id"))
+
+      _ <- sendRequest("POST", s"/tables/$table2/columns", createIdentifierStringColumnJson)
+
+      _ <- sendRequest("POST", s"/tables/$table1/columns", createLinkColumnJson)
+
+      deleteResult <- sendRequest("DELETE", "/tables/1")
+    } yield {
+      assertEquals(expectedOkJson, deleteResult)
+    }
+  }
+
+  @Test
+  def deleteTableWithOneAttachmentColumn(implicit c: TestContext): Unit = okTest {
+    val createLinkColumnJson = Json.obj(
+      "columns" -> Json.arr(
+        Json.obj(
+          "name" -> "Test Col",
+          "kind" -> "attachment"
+        )
+      )
+    )
+
+    for {
+      table1 <- sendRequest("POST", "/tables", createTableJson).map(_.getLong("id"))
+
+      _ <- sendRequest("POST", s"/tables/$table1/columns", createLinkColumnJson)
+
+      deleteResult <- sendRequest("DELETE", "/tables/1")
+    } yield {
+      assertEquals(expectedOkJson, deleteResult)
+    }
+  }
+
+  @Test
   def deleteLinkInBothDirectionsAndCheckForDependentRows(implicit c: TestContext): Unit = {
     okTest {
       val createLinkColumnJson = Json.obj(


### PR DESCRIPTION
Wenn man eine Tabelle mit nur einer Spalte löschen will und diese Spalte vom Typ "attachment" oder "link" ist, läuft man auf folgenden Fehler:
`com.campudus.tableaux.DatabaseException: Last column can't be deleted`