### PR TITLE
deleting a row of a settings table should be allowed

### DIFF
--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -155,11 +155,6 @@ class TableauxModel(
 
   def deleteRow(table: Table, rowId: RowId): Future[EmptyObject] = {
     for {
-      _ <- table.tableType match {
-        case GenericTable => Future.successful(())
-        case SettingsTable => Future.failed(ForbiddenException("can't delete a row of a settings table", "row"))
-      }
-
       specialColumns <- retrieveColumns(table).map(_.filter({
         case _: AttachmentColumn => true
         case c: LinkColumn if c.linkDirection.constraint.deleteCascade => true

--- a/src/test/scala/com/campudus/tableaux/api/structure/SettingsTableTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/SettingsTableTest.scala
@@ -135,13 +135,16 @@ class SettingsTableTest extends TableauxTestBase {
   }
 
   @Test
-  def deleteRowOfSettingsTable(implicit c: TestContext): Unit = exceptionTest("error.request.forbidden.row") {
-    for {
-      tableId <- createSettingsTable()
+  def deleteRowOfSettingsTable(implicit c: TestContext): Unit =
+    okTest {
+      val expectedOkJson = Json.obj("status" -> "ok")
 
-      _ <- sendRequest("POST", s"/tables/$tableId/rows")
+      for {
+        tableId <- createSettingsTable()
 
-      _ <- sendRequest("DELETE", s"/tables/$tableId/rows/1")
-    } yield ()
-  }
+        _ <- sendRequest("POST", s"/tables/$tableId/rows")
+
+        test <- sendRequest("DELETE", s"/tables/$tableId/rows/1")
+      } yield assertEquals(expectedOkJson, test)
+    }
 }


### PR DESCRIPTION
accidential deletion from frontend is prevented by the frontend