### PR TITLE
deleted obsolete column and add some FKs

### DIFF
--- a/src/main/resources/schema/schema_v24.sql
+++ b/src/main/resources/schema/schema_v24.sql
@@ -1,0 +1,22 @@
+ALTER TABLE system_columns_lang
+  ADD FOREIGN KEY (table_id) REFERENCES system_table (table_id) ON DELETE CASCADE;
+
+ALTER TABLE system_column_groups
+  ADD FOREIGN KEY (table_id) REFERENCES system_table (table_id) ON DELETE CASCADE;
+
+ALTER TABLE system_attachment
+  ADD FOREIGN KEY (table_id) REFERENCES system_table (table_id) ON DELETE CASCADE;
+
+
+CREATE OR REPLACE FUNCTION drop_needs_translation_column(tableid BIGINT)
+  RETURNS TEXT AS $$
+BEGIN
+  EXECUTE 'ALTER TABLE user_table_lang_' || tableid || ' DROP COLUMN IF EXISTS needs_translation';
+  RETURN 'user_table_lang_' || tableid :: TEXT;
+END
+$$ LANGUAGE plpgsql;
+
+SELECT drop_needs_translation_column(table_id)
+FROM system_table;
+
+DROP FUNCTION drop_needs_translation_column( BIGINT );

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -145,7 +145,8 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
     setupVersion(readSchemaFile("schema_v20"), 20),
     setupVersion(readSchemaFile("schema_v21"), 21),
     setupVersion(readSchemaFile("schema_v22"), 22),
-    setupVersion(readSchemaFile("schema_v23"), 23)
+    setupVersion(readSchemaFile("schema_v23"), 23),
+    setupVersion(readSchemaFile("schema_v24"), 24)
   )
 
   private def readSchemaFile(name: String): String = {

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
@@ -102,7 +102,6 @@ class TableModel(val connection: DatabaseConnection) extends DatabaseQuery {
                            | CREATE TABLE user_table_lang_$id (
                            |   id BIGINT,
                            |   langtag VARCHAR(255),
-                           |   needs_translation BOOLEAN DEFAULT false,
                            |
                            |   PRIMARY KEY (id, langtag),
                            |

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -69,8 +69,8 @@ class SystemControllerTest extends TableauxTestBase {
     okTest {
       val expectedJson = Json.obj(
         "database" -> Json.obj(
-          "current" -> 23,
-          "specification" -> 23
+          "current" -> 24,
+          "specification" -> 24
         )
       )
 


### PR DESCRIPTION
The info of column `needs_translation` of table `user_table_lang_x` moved to tables `user_table_annotations_x`.

added FK Constraints to tables:

- system_columns_lang
- system_column_groups
- system_attachment

