### PR TITLE
Also run Travis Tests against Postgres 10.7 and 11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 sudo: false
-dist: trusty
+dist: xenial
 cache:
   directories:
   - $HOME/.m2
@@ -18,6 +18,25 @@ matrix:
     - name: "Test with postgresql 9.6"
       addons:
         postgresql: '9.6'
+    - name: "Test with postgresql 10.7"
+      addons:
+        postgresql: "10.7"
+        apt:
+          packages:
+          - postgresql-10
+          - postgresql-client-10
+      before_install:
+        - sudo cp /etc/postgresql/{9.6,10}/main/pg_hba.conf
+        - sudo /etc/init.d/postgresql restart
+    - name: "Test with postgresql 11.2"
+      addons:
+        postgresql: "11.2"
+      before_install:
+        - sudo apt-get update
+        - sudo apt-get --yes remove postgresql\*
+        - sudo apt-get install -y postgresql-11 postgresql-client-11
+        - sudo cp /etc/postgresql/{9.6,11}/main/pg_hba.conf
+        - sudo service postgresql restart 11
 install: /bin/true
 before_script:
 - psql -c 'SHOW SERVER_VERSION;' -U postgres


### PR DESCRIPTION
Had to use xenial distribution because of available postgres packages and therefore openjdk8 because oraclejdk8 is not available in xenial.