### PR TITLE
Feature/auth/enrich media with permissions

### DIFF
--- a/src/main/scala/com/campudus/tableaux/controller/MediaController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/MediaController.scala
@@ -40,7 +40,7 @@ class MediaController(
     override protected val repository: FolderModel,
     protected val fileModel: FileModel,
     protected val attachmentModel: AttachmentModel,
-    protected val roleModel: RoleModel
+    implicit protected val roleModel: RoleModel
 )(implicit requestContext: RequestContext)
     extends Controller[FolderModel] {
 
@@ -63,7 +63,7 @@ class MediaController(
     for {
       subfolders <- repository.retrieveSubfolders(folder)
       files <- fileModel.retrieveFromFolder(folder, sortByLangtag)
-    } yield ExtendedFolder(folder, subfolders, files map ExtendedFile)
+    } yield ExtendedFolder(folder, subfolders, files.map(ExtendedFile))
   }
 
   def addNewFolder(name: String, description: String, parent: Option[FolderId]): Future[Folder] = {

--- a/src/main/scala/com/campudus/tableaux/controller/MediaController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/MediaController.scala
@@ -68,7 +68,7 @@ class MediaController(
 
   def addNewFolder(name: String, description: String, parent: Option[FolderId]): Future[Folder] = {
     for {
-      _ <- roleModel.checkAuthorization(requestContext.getUserRoles, Create, ScopeMedia)
+      _ <- roleModel.checkAuthorization(Create, ScopeMedia)
       folder <- repository.add(name, description, parent)
     } yield folder
   }
@@ -101,7 +101,7 @@ class MediaController(
       folder: Option[FolderId]
   ): Future[TemporaryFile] = {
     for {
-      _ <- roleModel.checkAuthorization(requestContext.getUserRoles, Create, ScopeMedia)
+      _ <- roleModel.checkAuthorization(Create, ScopeMedia)
       file <- fileModel.add(title, description, externalName, folder).map(TemporaryFile)
     } yield file
   }
@@ -258,7 +258,7 @@ class MediaController(
 
   def deleteFile(uuid: UUID): Future[TableauxFile] = {
     for {
-      _ <- roleModel.checkAuthorization(requestContext.getUserRoles, Delete, ScopeMedia)
+      _ <- roleModel.checkAuthorization(Delete, ScopeMedia)
 
       (file, paths) <- retrieveFile(uuid, withTmp = true)
 
@@ -286,7 +286,7 @@ class MediaController(
 
   def deleteFile(uuid: UUID, langtag: String): Future[TableauxFile] = {
     for {
-      _ <- roleModel.checkAuthorization(requestContext.getUserRoles, Delete, ScopeMedia)
+      _ <- roleModel.checkAuthorization(Delete, ScopeMedia)
 
       (_, paths) <- retrieveFile(uuid, withTmp = true)
 

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -187,7 +187,7 @@ class StructureController(
 
     for {
       table <- tableStruc.retrieve(tableId)
-      _ <- roleModel.checkAuthorization(requestContext.getUserRoles, Delete, ScopeTable, ComparisonObjects(table))
+      _ <- roleModel.checkAuthorization(Delete, ScopeTable, ComparisonObjects(table))
       columns <- columnStruc.retrieveAll(table)
 
       // only delete special column before deleting table;

--- a/src/main/scala/com/campudus/tableaux/database/domain/folder.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/folder.scala
@@ -48,6 +48,6 @@ case class ExtendedFolder(
           "files" -> compatibilityGet(files)
         ))
 
-    roleModel.enrichDomainObject(requestContext.getUserRoles, extendedFolderJson, ScopeMedia)
+    roleModel.enrichDomainObject(extendedFolderJson, ScopeMedia)
   }
 }

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/RoleModel.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/RoleModel.scala
@@ -91,14 +91,23 @@ case class RoleModel(jsonObject: JsonObject) {
   def getPermissionsForRoles(roleNames: Seq[String]): Seq[Permission] =
     role2permissions.filter({ case (key, _) => roleNames.contains(key) }).values.flatten.toSeq
 
+  def filterPermissions(roleNames: Seq[String], permissionType: PermissionType, scope: Scope): Seq[Permission] =
+    filterPermissions(roleNames, permissionType, None, scope)
+
+  def filterPermissions(roleNames: Seq[String],
+                        permissionType: PermissionType,
+                        action: Action,
+                        scope: Scope): Seq[Permission] =
+    filterPermissions(roleNames, permissionType, Some(action), scope)
+
   /**
     * Filters permissions for role name, permissionType, action and scope
     *
     * @return a subset of permissions
     */
-  def filterPermissions(roleNames: Seq[String],
+  private def filterPermissions(roleNames: Seq[String],
                         permissionType: PermissionType,
-                        action: Action,
+                                actionOpt: Option[Action],
                         scope: Scope): Seq[Permission] = {
 
     val permissions: Seq[Permission] =
@@ -107,7 +116,7 @@ case class RoleModel(jsonObject: JsonObject) {
     permissions
       .filter(_.permissionType == permissionType)
       .filter(_.scope == scope)
-      .filter(_.actions.contains(action))
+      .filter(permission => actionOpt.forall(permission.actions.contains(_)))
   }
 
   def println(): Unit =

--- a/src/test/scala/com/campudus/tableaux/api/auth/permission/RoleModelTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/auth/permission/RoleModelTest.scala
@@ -304,4 +304,41 @@ class RoleModelTest {
       roleModel.filterPermissions(Seq("view-tables1"), Deny, View, ScopeTable)
     Assert.assertEquals(1, permissions.size)
   }
+
+  @Test
+  def filterPermissions_withoutDefinedAction_returnsAllPermissions(): Unit = {
+
+    val json: JsonObject = Json.fromObjectString("""
+                                                   |{
+                                                   |  "view-tables1": [
+                                                   |    {
+                                                   |      "type": "grant",
+                                                   |      "action": ["view"],
+                                                   |      "scope": "table"
+                                                   |    },
+                                                   |    {
+                                                   |      "type": "grant",
+                                                   |      "action": ["edit"],
+                                                   |      "scope": "table"
+                                                   |    }
+                                                   |  ],
+                                                   |  "view-tables2": [
+                                                   |    {
+                                                   |      "type": "grant",
+                                                   |      "action": ["view"],
+                                                   |      "scope": "table"
+                                                   |    },
+                                                   |    {
+                                                   |      "type": "grant",
+                                                   |      "action": ["delete"],
+                                                   |      "scope": "table"
+                                                   |    }
+                                                   |  ]
+                                                   |}""".stripMargin)
+
+    val roleModel: RoleModel = RoleModel(json)
+    val permissions: Seq[Permission] =
+      roleModel.filterPermissions(Seq("view-tables1", "view-tables2"), Grant, ScopeTable)
+    Assert.assertEquals(4, permissions.size)
+  }
 }


### PR DESCRIPTION
Proof of concept:

- [x] a check method for `POST`, `PUT`, `PATCH` und `DELETE` requests
- [x] a enrich method for selected `GET` requests, to extend response items with permissions objects
- [ ] a filter method for `GET` requests, to only return viewable items

next step is to filter items based on provided user roles and permission config