### PR TITLE
Feature/auth/filter response items

### DIFF
--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -13,7 +13,7 @@ import com.campudus.tableaux.database.domain.{
 }
 import com.campudus.tableaux.database.model.StructureModel
 import com.campudus.tableaux.database.model.TableauxModel._
-import com.campudus.tableaux.router.auth.permission.{ComparisonObjects, Delete, RoleModel, ScopeTable}
+import com.campudus.tableaux.router.auth.permission.{ComparisonObjects, Delete, RoleModel, ScopeTable, View}
 import com.campudus.tableaux.{ForbiddenException, RequestContext, TableauxConfig}
 
 import scala.concurrent.Future
@@ -43,7 +43,7 @@ class StructureController(
 
     for {
       table <- tableStruc.retrieve(tableId)
-      _ = roleModel.filterDomainObjects[Table](ScopeTable, Seq(table), true)
+      _ <- roleModel.checkAuthorization(View, ScopeTable, ComparisonObjects(table))
     } yield table
   }
 

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -41,13 +41,21 @@ class StructureController(
     checkArguments(greaterZero(tableId))
     logger.info(s"retrieveTable $tableId")
 
-    tableStruc.retrieve(tableId)
+    for {
+      table <- tableStruc.retrieve(tableId)
+      _ = roleModel.filterDomainObjects[Table](ScopeTable, Seq(table), true)
+    } yield table
   }
 
   def retrieveTables(): Future[TableSeq] = {
     logger.info(s"retrieveTables")
 
-    tableStruc.retrieveAll().map(TableSeq)
+    for {
+      tableSeq: Seq[Table] <- tableStruc.retrieveAll()
+    } yield {
+      val filteredTables: Seq[Table] = roleModel.filterDomainObjects[Table](ScopeTable, tableSeq)
+      TableSeq(filteredTables)
+    }
   }
 
   def createColumns(tableId: TableId, columns: Seq[CreateColumn]): Future[ColumnSeq] = {

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/Condition.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/Condition.scala
@@ -15,7 +15,9 @@ object ConditionContainer {
       Option(jsonObject.getJsonObject("column")).map(ConditionColumn).getOrElse(NoneCondition)
 
     val conditionLangtag: ConditionOption =
-      Option(Json.obj("langtag" -> jsonObject.getString("langtag"))).map(ConditionLangtag).getOrElse(NoneCondition)
+      Option(jsonObject.getString("langtag"))
+        .map(langtags => ConditionLangtag(Json.obj("langtag" -> langtags)))
+        .getOrElse(NoneCondition)
 
     new ConditionContainer(conditionTable, conditionColumn, conditionLangtag)
   }

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/Condition.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/Condition.scala
@@ -27,16 +27,22 @@ case class ConditionContainer(
     conditionTable: ConditionOption,
     conditionColumn: ConditionOption,
     conditionLangtag: ConditionOption
-)
+) {
+
+  def isMatching(objects: ComparisonObjects): Boolean =
+    conditionTable.isMatching(objects) &&
+      conditionColumn.isMatching(objects) &&
+      conditionLangtag.isMatching(objects)
+}
 
 abstract class ConditionOption(jsonObject: JsonObject) {
   val conditionMap: Map[String, String] = toMap(jsonObject)
 
-  protected def toMap(jsonObject: JsonObject) = {
+  protected def toMap(jsonObject: JsonObject): Map[String, String] = {
     jsonObject.asMap.toMap.asInstanceOf[Map[String, String]]
   }
 
-  def isMatching(subjects: ComparisonObjects) = false
+  def isMatching(objects: ComparisonObjects): Boolean = false
 }
 
 case class ConditionTable(jsonObject: JsonObject) extends ConditionOption(jsonObject) {
@@ -46,7 +52,7 @@ case class ConditionTable(jsonObject: JsonObject) extends ConditionOption(jsonOb
       conditionMap.forall({
         case (property, regex) => {
 
-          // TODO possibly not the best idea to stingify every property and match with regex!?
+          // TODO possibly not the best idea to stringify every property and match with regex!?
           property match {
             case "id" => table.id.toString.matches(regex)
             case "name" => table.name.matches(regex)
@@ -76,5 +82,5 @@ case class ConditionLangtag(jsonObject: JsonObject) extends ConditionOption(json
 // TODO implement regex validation
 
 case object NoneCondition extends ConditionOption(Json.emptyObj()) {
-  override def isMatching(subjects: ComparisonObjects) = true
+  override def isMatching(subjects: ComparisonObjects): Boolean = true
 }

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/Permission.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/Permission.scala
@@ -13,19 +13,10 @@ case class Permission(
   def isMatching(subjects: ComparisonObjects): Boolean = {
 
     // TODO log which permission/role granted access
-    permissionType match {
-      // TODO split up method when implementing DENY
-      case Grant => {
-        scope match {
-          case ScopeMedia => true
-          case ScopeTable => condition.conditionTable.isMatching(subjects)
-        }
-      }
-      case Deny => {
-        // TODO
-        println(s"XXX: NOT IMPLEMENTED!!!")
-        false
-      }
+    scope match {
+      case ScopeMedia => true
+      case ScopeTable => condition.conditionTable.isMatching(subjects)
+      case _ => ???
     }
   }
 }

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/Permission.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/Permission.scala
@@ -1,24 +1,17 @@
 package com.campudus.tableaux.router.auth.permission
 
 import com.campudus.tableaux.helper.JsonUtils.asSeqOf
+import com.typesafe.scalalogging.LazyLogging
 import org.vertx.scala.core.json.JsonObject
 
 case class Permission(
     permissionType: PermissionType,
     actions: Seq[Action],
     scope: Scope,
-    condition: ConditionContainer
-) {
+    conditions: ConditionContainer
+) extends LazyLogging {
 
-  def isMatching(subjects: ComparisonObjects): Boolean = {
-
-    // TODO log which permission/role granted access
-    scope match {
-      case ScopeMedia => true
-      case ScopeTable => condition.conditionTable.isMatching(subjects)
-      case _ => ???
-    }
-  }
+  def isMatching(objects: ComparisonObjects): Boolean = conditions.isMatching(objects)
 }
 
 object Permission {

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/Permission.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/Permission.scala
@@ -30,7 +30,9 @@ object Permission {
   }
 }
 
-sealed trait PermissionType
+sealed trait PermissionType {
+  def isAccessAllowed: Boolean = false
+}
 
 object PermissionType {
 
@@ -43,6 +45,8 @@ object PermissionType {
   }
 }
 
-case object Grant extends PermissionType
+case object Grant extends PermissionType {
+  override def isAccessAllowed: Boolean = true
+}
 
 case object Deny extends PermissionType

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/Permission.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/Permission.scala
@@ -5,6 +5,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.vertx.scala.core.json.JsonObject
 
 case class Permission(
+    roleName: String,
     permissionType: PermissionType,
     actions: Seq[Action],
     scope: Scope,
@@ -16,14 +17,16 @@ case class Permission(
 
 object Permission {
 
-  def apply(jsonObject: JsonObject): Permission = {
+  def apply(jsonObject: JsonObject): Permission = this.apply(jsonObject, "")
+
+  def apply(jsonObject: JsonObject, roleName: String): Permission = {
     val permissionType: PermissionType = PermissionType(jsonObject.getString("type"))
     val actionString: Seq[String] = asSeqOf[String](jsonObject.getJsonArray("action"))
     val actions: Seq[Action] = actionString.map(key => Action(key))
     val scope: Scope = Scope(jsonObject.getString("scope"))
     val condition: ConditionContainer = ConditionContainer(jsonObject.getJsonObject("condition"))
 
-    new Permission(permissionType, actions, scope, condition)
+    new Permission(roleName, permissionType, actions, scope, condition)
   }
 }
 

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/RoleModel.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/RoleModel.scala
@@ -13,10 +13,6 @@ object RoleModel {
   def apply(jsonObject: JsonObject): RoleModel = {
     new RoleModel(jsonObject)
   }
-
-  def apply(jsonObjectString: String): RoleModel = {
-    new RoleModel(Json.fromObjectString(jsonObjectString))
-}
 }
 
 /**

--- a/src/test/scala/com/campudus/tableaux/api/auth/MediaControllerAuthTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/auth/MediaControllerAuthTest.scala
@@ -56,18 +56,16 @@ class MediaControllerAuthTest_checkAuthorization extends MediaControllerAuthTest
 
   @Test
   def createFolder_authorized_ok(implicit c: TestContext): Unit = okTest {
-    setRequestRoles("create-media")
-
-    val roleModel = RoleModel("""
-                                |{
-                                |  "create-media": [
-                                |    {
-                                |      "type": "grant",
-                                |      "action": ["create"],
-                                |      "scope": "media"
-                                |    }
-                                |  ]
-                                |}""".stripMargin)
+    val roleModel = initRoleModel("""
+                                    |{
+                                    |  "create-media": [
+                                    |    {
+                                    |      "type": "grant",
+                                    |      "action": ["create"],
+                                    |      "scope": "media"
+                                    |    }
+                                    |  ]
+                                    |}""".stripMargin)
 
     val controller = createMediaController(roleModel)
     controller.addNewFolder("folder", "", None)
@@ -83,19 +81,16 @@ class MediaControllerAuthTest_checkAuthorization extends MediaControllerAuthTest
 
   @Test
   def createFile_authorized_ok(implicit c: TestContext): Unit = okTest {
-
-    setRequestRoles("create-media")
-
-    val roleModel = RoleModel("""
-                                |{
-                                |  "create-media": [
-                                |    {
-                                |      "type": "grant",
-                                |      "action": ["create"],
-                                |      "scope": "media"
-                                |    }
-                                |  ]
-                                |}""".stripMargin)
+    val roleModel = initRoleModel("""
+                                    |{
+                                    |  "create-media": [
+                                    |    {
+                                    |      "type": "grant",
+                                    |      "action": ["create"],
+                                    |      "scope": "media"
+                                    |    }
+                                    |  ]
+                                    |}""".stripMargin)
 
     val controller = createMediaController(roleModel)
     controller.addFile(MultiLanguageValue("de-DE" -> "file"),
@@ -118,23 +113,21 @@ class MediaControllerAuthTest_checkAuthorization extends MediaControllerAuthTest
   @Test
   def deleteFile_authorized_ok(implicit c: TestContext): Unit =
     okTest {
-      setRequestRoles("delete-media")
-
-      val roleModel = RoleModel("""
-                                  |{
-                                  |  "delete-media": [
-                                  |    {
-                                  |      "type": "grant",
-                                  |      "action": ["delete"],
-                                  |      "scope": "media"
-                                  |    }
-                                  |  ]
-                                  |}""".stripMargin)
+      val roleModel = initRoleModel("""
+                                      |{
+                                      |  "delete-media": [
+                                      |    {
+                                      |      "type": "grant",
+                                      |      "action": ["delete"],
+                                      |      "scope": "media"
+                                      |    }
+                                      |  ]
+                                      |}""".stripMargin)
 
       val controller = createMediaController(roleModel)
 
       for {
-        file <- insertTestFile
+        file <- insertTestFile()
         _ <- controller.deleteFile(file.uuid)
       } yield ()
     }
@@ -145,7 +138,7 @@ class MediaControllerAuthTest_checkAuthorization extends MediaControllerAuthTest
       val controller = createMediaController()
 
       for {
-        file <- insertTestFile
+        file <- insertTestFile()
         _ <- controller.deleteFile(file.uuid)
       } yield ()
     }
@@ -153,23 +146,21 @@ class MediaControllerAuthTest_checkAuthorization extends MediaControllerAuthTest
   @Test
   def deleteFileLang_authorized_ok(implicit c: TestContext): Unit =
     okTest {
-      setRequestRoles("delete-media")
-
-      val roleModel = RoleModel("""
-                                  |{
-                                  |  "delete-media": [
-                                  |    {
-                                  |      "type": "grant",
-                                  |      "action": ["delete"],
-                                  |      "scope": "media"
-                                  |    }
-                                  |  ]
-                                  |}""".stripMargin)
+      val roleModel = initRoleModel("""
+                                      |{
+                                      |  "delete-media": [
+                                      |    {
+                                      |      "type": "grant",
+                                      |      "action": ["delete"],
+                                      |      "scope": "media"
+                                      |    }
+                                      |  ]
+                                      |}""".stripMargin)
 
       val controller = createMediaController(roleModel)
 
       for {
-        file <- insertTestFile
+        file <- insertTestFile()
         _ <- controller.deleteFile(file.uuid, "de-DE")
       } yield ()
     }
@@ -180,7 +171,7 @@ class MediaControllerAuthTest_checkAuthorization extends MediaControllerAuthTest
       val controller = createMediaController()
 
       for {
-        file <- insertTestFile
+        file <- insertTestFile()
         _ <- controller.deleteFile(file.uuid, "de-DE")
       } yield ()
     }
@@ -210,19 +201,16 @@ class MediaControllerAuthTest_enrichAuthorization extends MediaControllerAuthTes
 
   @Test
   def enrich_createGranted_onlyCreateIsAllowed(implicit c: TestContext): Unit = {
-
-    setRequestRoles("create-media")
-
-    val roleModel = RoleModel("""
-                                |{
-                                |  "create-media": [
-                                |    {
-                                |      "type": "grant",
-                                |      "action": ["create"],
-                                |      "scope": "media"
-                                |    }
-                                |  ]
-                                |}""".stripMargin)
+    val roleModel = initRoleModel("""
+                                    |{
+                                    |  "create-media": [
+                                    |    {
+                                    |      "type": "grant",
+                                    |      "action": ["create"],
+                                    |      "scope": "media"
+                                    |    }
+                                    |  ]
+                                    |}""".stripMargin)
 
     val controller = createMediaController(roleModel)
 
@@ -240,19 +228,16 @@ class MediaControllerAuthTest_enrichAuthorization extends MediaControllerAuthTes
 
   @Test
   def enrich_editAndDeleteGranted_onlyEditAndDeleteAreAllowed(implicit c: TestContext): Unit = {
-
-    setRequestRoles("edit-delete-media")
-
-    val roleModel = RoleModel("""
-                                |{
-                                |  "edit-delete-media": [
-                                |    {
-                                |      "type": "grant",
-                                |      "action": ["edit", "delete"],
-                                |      "scope": "media"
-                                |    }
-                                |  ]
-                                |}""".stripMargin)
+    val roleModel = initRoleModel("""
+                                    |{
+                                    |  "edit-delete-media": [
+                                    |    {
+                                    |      "type": "grant",
+                                    |      "action": ["edit", "delete"],
+                                    |      "scope": "media"
+                                    |    }
+                                    |  ]
+                                    |}""".stripMargin)
 
     val controller = createMediaController(roleModel)
 
@@ -274,26 +259,23 @@ class MediaControllerAuthTest_enrichAuthorization extends MediaControllerAuthTes
 
   @Test
   def enrich_editAndDeleteGranted_deleteDenied_onlyEditIsAllowed(implicit c: TestContext): Unit = {
-
-    setRequestRoles("edit-delete-media", "NOT-delete-media")
-
-    val roleModel = RoleModel("""
-                                |{
-                                |  "edit-delete-media": [
-                                |    {
-                                |      "type": "grant",
-                                |      "action": ["edit", "delete"],
-                                |      "scope": "media"
-                                |    }
-                                |  ],
-                                |  "NOT-delete-media": [
-                                |    {
-                                |      "type": "deny",
-                                |      "action": ["delete"],
-                                |      "scope": "media"
-                                |    }
-                                |  ]
-                                |}""".stripMargin)
+    val roleModel = initRoleModel("""
+                                    |{
+                                    |  "edit-delete-media": [
+                                    |    {
+                                    |      "type": "grant",
+                                    |      "action": ["edit", "delete"],
+                                    |      "scope": "media"
+                                    |    }
+                                    |  ],
+                                    |  "NOT-delete-media": [
+                                    |    {
+                                    |      "type": "deny",
+                                    |      "action": ["delete"],
+                                    |      "scope": "media"
+                                    |    }
+                                    |  ]
+                                    |}""".stripMargin)
 
     val controller = createMediaController(roleModel)
 

--- a/src/test/scala/com/campudus/tableaux/api/auth/permission/RoleModelTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/auth/permission/RoleModelTest.scala
@@ -28,7 +28,7 @@ class RoleModelTest {
                                                    |}""".stripMargin)
 
     val roleModel: RoleModel = RoleModel(json)
-    val permissions: Seq[Permission] = roleModel.getPermissionsForRoles(Seq("view-tables"))
+    val permissions: Seq[Permission] = roleModel.filterPermissions(Seq("view-tables"))
     Assert.assertEquals(1, permissions.size)
   }
 
@@ -63,7 +63,7 @@ class RoleModelTest {
                                                    |}""".stripMargin)
 
     val roleModel: RoleModel = RoleModel(json)
-    val permissions: Seq[Permission] = roleModel.getPermissionsForRoles(Seq("view-tables"))
+    val permissions: Seq[Permission] = roleModel.filterPermissions(Seq("view-tables"))
     Assert.assertEquals(2, permissions.size)
   }
 
@@ -82,7 +82,7 @@ class RoleModelTest {
                                                    |}""".stripMargin)
     val roleModel: RoleModel = RoleModel(json)
 
-    val permissions: Seq[Permission] = roleModel.getPermissionsForRoles(Seq("view-media"))
+    val permissions: Seq[Permission] = roleModel.filterPermissions(Seq("view-media"))
     Assert.assertEquals(1, permissions.size)
   }
 
@@ -169,7 +169,7 @@ class RoleModelTest {
                                                    |}""".stripMargin)
 
     val roleModel: RoleModel = RoleModel(json)
-    val permissions: Seq[Permission] = roleModel.getPermissionsForRoles(Seq("view-tables", "view-media"))
+    val permissions: Seq[Permission] = roleModel.filterPermissions(Seq("view-tables", "view-media"))
     Assert.assertEquals(2, permissions.size)
   }
 

--- a/src/test/scala/com/campudus/tableaux/testtools/TableauxTestBase.scala
+++ b/src/test/scala/com/campudus/tableaux/testtools/TableauxTestBase.scala
@@ -5,6 +5,7 @@ import com.campudus.tableaux.database.domain.DomainObject
 import com.campudus.tableaux.database.model.SystemModel
 import com.campudus.tableaux.database.model.TableauxModel.{ColumnId, RowId, TableId}
 import com.campudus.tableaux.helper.FileUtils
+import com.campudus.tableaux.router.auth.permission.RoleModel
 import com.campudus.tableaux.testtools.RequestCreation.ColumnType
 import com.campudus.tableaux.{CustomException, RequestContext, Starter, TableauxConfig}
 import com.typesafe.scalalogging.LazyLogging
@@ -244,7 +245,17 @@ trait TableauxTestBase
   @After
   def after(context: TestContext): Unit = vertx.close(context.asyncAssertSuccess())
 
-  def setRequestRoles(roles: String*) = {
+  /**
+    * Initializes the RoleModel with the given config and also sets up the requestsContext with all provided roles
+    */
+  def initRoleModel(roleConfig: String) = {
+    val roleModel = RoleModel(Json.fromObjectString(roleConfig.stripMargin))
+
+    setRequestRoles(roleModel.role2permissions.keySet.toSeq: _*)
+    roleModel
+  }
+
+  private def setRequestRoles(roles: String*) = {
     requestContext.principal = Json.obj("realm_access" -> Json.obj("roles" -> roles))
   }
 


### PR DESCRIPTION
Proof of concept:

- [x] a check method for `POST`, `PUT`, `PATCH` und `DELETE` requests
- [x] a enrich method for selected `GET` requests, to extend response items with permissions objects
- [x] a filter method for `GET` requests, to only return viewable items

next step is to do more filtering that we can test the backend together with keycloak and tableaux-frontend