### PR TITLE
Add endpoint to query single cell's annotations

### DIFF
--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -340,6 +340,16 @@ class TableauxController(
     } yield rows
   }
 
+  def retrieveCellAnnotations(tableId: TableId, columnId: ColumnId, rowId: RowId): Future[CellLevelAnnotations] = {
+    checkArguments(greaterZero(tableId), greaterThan(columnId, -1, "columnId"), greaterZero(rowId))
+    logger.info(s"retrieveCell $tableId $columnId $rowId")
+
+    for {
+      table <- repository.retrieveTable(tableId)
+      annotations <- repository.retrieveCellAnnotations(table, columnId, rowId)
+    } yield annotations
+  }
+
   def retrieveCell(tableId: TableId, columnId: ColumnId, rowId: RowId): Future[Cell[_]] = {
     checkArguments(greaterZero(tableId), greaterThan(columnId, -1, "columnId"), greaterZero(rowId))
     logger.info(s"retrieveCell $tableId $columnId $rowId")

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -656,6 +656,19 @@ class TableauxModel(
     } yield ()
   }
 
+  def retrieveCellAnnotations(
+      table: Table,
+      columnId: ColumnId,
+      rowId: RowId,
+      isInternalCall: Boolean = true
+  ): Future[CellLevelAnnotations] = {
+    for {
+      column <- retrieveColumn(table, columnId)
+      _ <- roleModel.checkAuthorization(ViewCellValue, ScopeColumn, ComparisonObjects(table, column), isInternalCall)
+      (_, cellLevelAnnotations) <- retrieveRowModel.retrieveAnnotations(column.table.id, rowId, Seq(column))
+    } yield cellLevelAnnotations
+  }
+
   def retrieveCell(
       table: Table,
       columnId: ColumnId,

--- a/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
@@ -86,6 +86,8 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
     router.getWithRegex(tableHistory).handler(retrieveTableHistory)
     router.getWithRegex(tableHistoryWithLangtag).handler(retrieveTableHistoryWithLangtag)
 
+    router.getWithRegex(cellAnnotations).handler(retrieveCellAnnotations)
+
     // DELETE
     router.deleteWithRegex(cellAnnotation).handler(deleteCellAnnotation)
     router.deleteWithRegex(cellAnnotationLangtag).handler(deleteCellAnnotationLangtag)
@@ -252,6 +254,18 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
           controller.retrieveCell(tableId, columnId, rowId)
         }
       )
+    }
+  }
+
+  private def retrieveCellAnnotations(context: RoutingContext): Unit = {
+    for {
+      tableId <- getTableId(context)
+      columnId <- getColumnId(context)
+      rowId <- getRowId(context)
+    } yield {
+      sendReply(context, asyncGetReply {
+        controller.retrieveCellAnnotations(tableId, columnId, rowId)
+      })
     }
   }
 

--- a/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
@@ -263,9 +263,12 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
       columnId <- getColumnId(context)
       rowId <- getRowId(context)
     } yield {
-      sendReply(context, asyncGetReply {
-        controller.retrieveCellAnnotations(tableId, columnId, rowId)
-      })
+      sendReply(
+        context,
+        asyncGetReply {
+          controller.retrieveCellAnnotations(tableId, columnId, rowId)
+        }
+      )
     }
   }
 

--- a/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
@@ -41,6 +41,34 @@ class CellLevelAnnotationsTest extends TableauxTestBase {
   }
 
   @Test
+  def retrieveCellAnnotation(implicit c: TestContext): Unit = {
+    okTest {
+      val annotationJson = Json.obj("type" -> "info", "value" -> "I am an annotation")
+
+      for {
+        tableId <- createEmptyDefaultTable()
+        result <- sendRequest("POST", s"/tables/$tableId/rows")
+        rowId = result.getLong("id")
+        cellAnnotationUrl = s"/tables/$tableId/columns/1/rows/$rowId/annotations"
+
+        _ <- sendRequest(
+          "POST",
+          cellAnnotationUrl,
+          annotationJson
+        )
+
+        storedAnnotation <- sendRequest("GET", cellAnnotationUrl)
+      } yield {
+
+        val cellAnnotation = storedAnnotation.getJsonArray("annotations").getJsonArray(0).getJsonObject(0)
+        println(cellAnnotation)
+        assertEquals(cellAnnotation.getValue("text"), annotationJson.getValue("text"))
+        assertEquals(cellAnnotation.getValue("type"), annotationJson.getValue("type"))
+      }
+    }
+  }
+
+  @Test
   def addAndDeleteMultipleAnnotationsWithoutLangtags(implicit c: TestContext): Unit = {
     okTest {
       for {

--- a/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
@@ -61,7 +61,6 @@ class CellLevelAnnotationsTest extends TableauxTestBase {
       } yield {
 
         val cellAnnotation = storedAnnotation.getJsonArray("annotations").getJsonArray(0).getJsonObject(0)
-        println(cellAnnotation)
         assertEquals(cellAnnotation.getValue("text"), annotationJson.getValue("text"))
         assertEquals(cellAnnotation.getValue("type"), annotationJson.getValue("type"))
       }


### PR DESCRIPTION
`GET /tables/:tableID/columns/:columnID/rows/:rowID/annotations` -> {"annotations": CellLevelAnnotations }