### PR TITLE
Add table kind taxonomy

### DIFF
--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -289,7 +289,8 @@ class StructureController(
               identifier = false,
               Seq(NameOnly("de", "Reihenfolge"), NameOnly("en", "Ordering")),
               false,
-              Option(Json.obj())
+              Option(Json.obj()),
+              hidden = true
             ),
             CreateSimpleColumn(
               "code",

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -272,12 +272,12 @@ class StructureController(
         Some(
           Seq(
             CreateSimpleColumn(
-              "title",
+              "name",
               None,
               ShortTextType,
               MultiLanguage,
               identifier = true,
-              Seq(NameOnly("de", "Name"), NameOnly("en", "Name")),
+              Seq(NameOnly("de", "Bezeichnung"), NameOnly("en", "Name")),
               false,
               Option(Json.obj())
             ),

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -315,7 +315,7 @@ class StructureController(
           singleDirection = false,
           identifier = false,
           Seq(NameOnly("de", "Oberkategorie"), NameOnly("en", "Parent category")),
-          Constraint(Cardinality(1, 1), false),
+          Constraint(Cardinality(0, 1), false),
           attributes,
           hidden = false
         )

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -526,7 +526,7 @@ class StructureController(
         case GenericTable => performChangeFx(table)
         case SettingsTable => Future.failed(ForbiddenException("can't change a column of a settings table", "column"))
         case TaxonomyTable =>
-          if (columnId > 3) performChangeFx(table)
+          if (columnId > 4) performChangeFx(table)
           else Future.failed(ForbiddenException("can't change a default column of a taxonmy table", "column"))
       }
 

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -318,7 +318,7 @@ class StructureController(
           Seq(NameOnly("de", "Oberkategorie"), NameOnly("en", "Parent category")),
           Constraint(Cardinality(0, 1), false),
           attributes,
-          hidden = false
+          hidden = true
         )
       )
       table <- tableStruc.retrieve(tableStub.id)

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -368,7 +368,7 @@ class StructureController(
         case GenericTable => columnStruc.delete(table, columnId)
         case TaxonomyTable =>
           if (columnId > 4) columnStruc.delete(table, columnId)
-          else Future.failed(ForbiddenException("can't delete a default columnd from a taxonomy table", "column"))
+          else Future.failed(ForbiddenException("can't delete a default column from a taxonomy table", "column"))
         case SettingsTable =>
           Future.failed(ForbiddenException("can't delete a column from a settings table", "column"))
       }

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -202,9 +202,9 @@ class StructureController(
       } yield table
     }
 
-  def createGenericTable(implicit user: TableauxUser) = buildTable(GenericTable, columns = None)
+  private def createGenericTable(implicit user: TableauxUser) = buildTable(GenericTable, columns = None)
 
-  def createSettingsTable(implicit user: TableauxUser) = buildTable(
+  private def createSettingsTable(implicit user: TableauxUser) = buildTable(
     SettingsTable,
     Some(Seq(
       CreateSimpleColumn(
@@ -257,7 +257,7 @@ class StructureController(
     ))
   )
 
-  def createTaxonomyTable(implicit user: TableauxUser) = (
+  private def createTaxonomyTable(implicit user: TableauxUser) = (
       tableName: String,
       hidden: Boolean,
       langtags: Option[Option[Seq[String]]],

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -366,7 +366,9 @@ class StructureController(
       _ <- roleModel.checkAuthorization(Delete, ScopeColumn, ComparisonObjects(table, column))
       _ <- table.tableType match {
         case GenericTable => columnStruc.delete(table, columnId)
-        case TaxonomyTable => columnStruc.delete(table, columnId)
+        case TaxonomyTable =>
+          if (columnId > 4) columnStruc.delete(table, columnId)
+          else Future.failed(ForbiddenException("can't delete a default columnd from a taxonomy table", "column"))
         case SettingsTable =>
           Future.failed(ForbiddenException("can't delete a column from a settings table", "column"))
       }

--- a/src/main/scala/com/campudus/tableaux/database/domain/table.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/table.scala
@@ -19,6 +19,7 @@ object TableType {
     string match {
       case GenericTable.NAME => GenericTable
       case SettingsTable.NAME => SettingsTable
+      case TaxonomyTable.NAME => TaxonomyTable
       case _ => throw new IllegalArgumentException("Unknown table type")
     }
   }
@@ -34,6 +35,10 @@ case object GenericTable extends TableType {
 
 case object SettingsTable extends TableType {
   override val NAME = "settings"
+}
+
+case object TaxonomyTable extends TableType {
+  override val NAME = "taxonomy"
 }
 
 object Table {

--- a/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
@@ -72,7 +72,7 @@ class TaxonomyTableTest extends TableauxTestBase {
     } yield ()
   }
   @Test
-  def changeLinkColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+  def changeParentColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
     for {
       tableId <- initTable()
       _ <- sendRequest("POST", s"/tables/$tableId/columns/4", Json.obj ("name" -> "anything"))
@@ -101,7 +101,7 @@ class TaxonomyTableTest extends TableauxTestBase {
     } yield ()
   }
   @Test
-  def deleteLinkColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+  def deleteParentColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
     for {
       tableId <- initTable()
       _ <- sendRequest("DELETE", s"/tables/$tableId/columns/4")

--- a/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
@@ -35,12 +35,12 @@ class TaxonomyTableTest extends TableauxTestBase {
       "type" -> "taxonomy",
       "displayName" -> Json.obj("de" -> "Tax"),
       "columns" -> Json.arr(
-          Json.obj("name" -> "title", "kind" -> "shorttext"),
-          Json.obj("name" -> "ordering", "kind" -> "numeric"),
-          Json.obj("name" -> "code", "kind" -> "shorttext"),
-          Json.obj("name" -> "parent", "kind" -> "link")
-        ),
-        "rows" -> Json.emptyArr()
+        Json.obj("name" -> "title", "kind" -> "shorttext"),
+        Json.obj("name" -> "ordering", "kind" -> "numeric"),
+        Json.obj("name" -> "code", "kind" -> "shorttext"),
+        Json.obj("name" -> "parent", "kind" -> "link")
+      ),
+      "rows" -> Json.emptyArr()
     )
     for {
       tableId <- initTable()
@@ -51,57 +51,63 @@ class TaxonomyTableTest extends TableauxTestBase {
   }
 
   @Test
-  def changeTitleColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+  def changeTitleColumn(implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
     for {
       tableId <- initTable()
-      _ <- sendRequest("POST", s"/tables/$tableId/columns/1", Json.obj ("name" -> "anything"))
-    } yield ()
-  }
-  @Test
-  def changeOrderingColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
-    for {
-      tableId <- initTable()
-      _ <- sendRequest("POST", s"/tables/$tableId/columns/2", Json.obj ("name" -> "anything"))
-    } yield ()
-  }
-  @Test
-  def changeCodeColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
-    for {
-      tableId <- initTable()
-      _ <- sendRequest("POST", s"/tables/$tableId/columns/3", Json.obj ("name" -> "anything"))
-    } yield ()
-  }
-  @Test
-  def changeParentColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
-    for {
-      tableId <- initTable()
-      _ <- sendRequest("POST", s"/tables/$tableId/columns/4", Json.obj ("name" -> "anything"))
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/1", Json.obj("name" -> "anything"))
     } yield ()
   }
 
   @Test
-  def deleteTitleColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+  def changeOrderingColumn(implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/2", Json.obj("name" -> "anything"))
+    } yield ()
+  }
+
+  @Test
+  def changeCodeColumn(implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/3", Json.obj("name" -> "anything"))
+    } yield ()
+  }
+
+  @Test
+  def changeParentColumn(implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/4", Json.obj("name" -> "anything"))
+    } yield ()
+  }
+
+  @Test
+  def deleteTitleColumn(implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
     for {
       tableId <- initTable()
       _ <- sendRequest("DELETE", s"/tables/$tableId/columns/1")
     } yield ()
   }
+
   @Test
-  def deleteOrderingColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+  def deleteOrderingColumn(implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
     for {
       tableId <- initTable()
       _ <- sendRequest("DELETE", s"/tables/$tableId/columns/2")
     } yield ()
   }
+
   @Test
-  def deleteCodeColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+  def deleteCodeColumn(implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
     for {
       tableId <- initTable()
       _ <- sendRequest("DELETE", s"/tables/$tableId/columns/3")
     } yield ()
   }
+
   @Test
-  def deleteParentColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+  def deleteParentColumn(implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
     for {
       tableId <- initTable()
       _ <- sendRequest("DELETE", s"/tables/$tableId/columns/4")
@@ -115,17 +121,17 @@ class TaxonomyTableTest extends TableauxTestBase {
       "type" -> "taxonomy",
       "displayName" -> Json.obj("de" -> "Tax"),
       "columns" -> Json.arr(
-          Json.obj("name" -> "title", "kind" -> "shorttext"),
-          Json.obj("name" -> "ordering", "kind" -> "numeric"),
-          Json.obj("name" -> "code", "kind" -> "shorttext"),
-          Json.obj("name" -> "parent", "kind" -> "link"),
-          Json.obj ("name" -> "fifth-column", "kind" -> "text")
-        ),
-        "rows" -> Json.emptyArr()
+        Json.obj("name" -> "title", "kind" -> "shorttext"),
+        Json.obj("name" -> "ordering", "kind" -> "numeric"),
+        Json.obj("name" -> "code", "kind" -> "shorttext"),
+        Json.obj("name" -> "parent", "kind" -> "link"),
+        Json.obj("name" -> "fifth-column", "kind" -> "text")
+      ),
+      "rows" -> Json.emptyArr()
     )
     for {
       tableId <- initTable()
-      _ <- sendRequest("POST",  s"/tables/$tableId/columns", Json.obj("name" -> "fifth-column", "kind" -> "text"))
+      _ <- sendRequest("POST", s"/tables/$tableId/columns", Json.obj("name" -> "fifth-column", "kind" -> "text"))
       table <- fetchTable(tableId)
     } yield {
       assertJSONEquals(expectedTable, table)
@@ -139,18 +145,18 @@ class TaxonomyTableTest extends TableauxTestBase {
       "type" -> "taxonomy",
       "displayName" -> Json.obj("de" -> "Tax"),
       "columns" -> Json.arr(
-          Json.obj("name" -> "title", "kind" -> "shorttext"),
-          Json.obj("name" -> "ordering", "kind" -> "numeric"),
-          Json.obj("name" -> "code", "kind" -> "shorttext"),
-          Json.obj("name" -> "parent", "kind" -> "link"),
-          Json.obj ("name" -> "fifth-columbia", "kind" -> "text")
-        ),
-        "rows" -> Json.emptyArr()
+        Json.obj("name" -> "title", "kind" -> "shorttext"),
+        Json.obj("name" -> "ordering", "kind" -> "numeric"),
+        Json.obj("name" -> "code", "kind" -> "shorttext"),
+        Json.obj("name" -> "parent", "kind" -> "link"),
+        Json.obj("name" -> "fifth-columbia", "kind" -> "text")
+      ),
+      "rows" -> Json.emptyArr()
     )
     for {
       tableId <- initTable()
-      _ <- sendRequest("POST",  s"/tables/$tableId/columns", Json.obj("name" -> "fifth-column", "kind" -> "text"))
-      _ <- sendRequest("POST",  s"/tables/$tableId/columns/5", Json.obj("name" -> "fifth-columbia"))
+      _ <- sendRequest("POST", s"/tables/$tableId/columns", Json.obj("name" -> "fifth-column", "kind" -> "text"))
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/5", Json.obj("name" -> "fifth-columbia"))
       table <- fetchTable(tableId)
     } yield {
       assertJSONEquals(expectedTable, table)
@@ -164,17 +170,17 @@ class TaxonomyTableTest extends TableauxTestBase {
       "type" -> "taxonomy",
       "displayName" -> Json.obj("de" -> "Tax"),
       "columns" -> Json.arr(
-          Json.obj("name" -> "title", "kind" -> "shorttext"),
-          Json.obj("name" -> "ordering", "kind" -> "numeric"),
-          Json.obj("name" -> "code", "kind" -> "shorttext"),
-          Json.obj("name" -> "parent", "kind" -> "link"),
-        ),
-        "rows" -> Json.emptyArr()
+        Json.obj("name" -> "title", "kind" -> "shorttext"),
+        Json.obj("name" -> "ordering", "kind" -> "numeric"),
+        Json.obj("name" -> "code", "kind" -> "shorttext"),
+        Json.obj("name" -> "parent", "kind" -> "link")
+      ),
+      "rows" -> Json.emptyArr()
     )
     for {
       tableId <- initTable()
-      _ <- sendRequest("POST",  s"/tables/$tableId/columns", Json.obj("name" -> "fifth-column", "kind" -> "text"))
-      _ <- sendRequest("DELETE",  s"/tables/$tableId/columns/5")
+      _ <- sendRequest("POST", s"/tables/$tableId/columns", Json.obj("name" -> "fifth-column", "kind" -> "text"))
+      _ <- sendRequest("DELETE", s"/tables/$tableId/columns/5")
       table <- fetchTable(tableId)
     } yield {
       assertJSONEquals(expectedTable, table)

--- a/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
@@ -35,7 +35,7 @@ class TaxonomyTableTest extends TableauxTestBase {
       "type" -> "taxonomy",
       "displayName" -> Json.obj("de" -> "Tax"),
       "columns" -> Json.arr(
-        Json.obj("name" -> "title", "kind" -> "shorttext"),
+        Json.obj("name" -> "name", "kind" -> "shorttext"),
         Json.obj("name" -> "ordering", "kind" -> "numeric"),
         Json.obj("name" -> "code", "kind" -> "shorttext"),
         Json.obj("name" -> "parent", "kind" -> "link")
@@ -121,7 +121,7 @@ class TaxonomyTableTest extends TableauxTestBase {
       "type" -> "taxonomy",
       "displayName" -> Json.obj("de" -> "Tax"),
       "columns" -> Json.arr(
-        Json.obj("name" -> "title", "kind" -> "shorttext"),
+        Json.obj("name" -> "name", "kind" -> "shorttext"),
         Json.obj("name" -> "ordering", "kind" -> "numeric"),
         Json.obj("name" -> "code", "kind" -> "shorttext"),
         Json.obj("name" -> "parent", "kind" -> "link"),

--- a/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
@@ -3,15 +3,17 @@ package com.campudus.tableaux.api.structure
 import com.campudus.tableaux.database.model.TableauxModel.TableId
 import com.campudus.tableaux.testtools.JsonAssertable
 import com.campudus.tableaux.testtools.TableauxTestBase
+
 import io.vertx.core.json.JsonObject
 import io.vertx.ext.unit.TestContext
 import io.vertx.ext.unit.junit.VertxUnitRunner
-import org.junit.Assert._
-import org.junit.Test
-import org.junit.runner.RunWith
 import org.vertx.scala.core.json.Json
 
 import scala.concurrent.Future
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
 
 @RunWith(classOf[VertxUnitRunner])
 class TaxonomyTableTest extends TableauxTestBase {

--- a/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
@@ -1,0 +1,183 @@
+package com.campudus.tableaux.api.structure
+
+import com.campudus.tableaux.database.model.TableauxModel.TableId
+import com.campudus.tableaux.testtools.TableauxTestBase
+
+import io.vertx.ext.unit.TestContext
+import io.vertx.ext.unit.junit.VertxUnitRunner
+import org.vertx.scala.core.json.Json
+
+import scala.concurrent.Future
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(classOf[VertxUnitRunner])
+class TaxonomyTableTest extends TableauxTestBase {
+
+  def initTable(): Future[TableId] = {
+    for {
+      result <- sendRequest(
+        "POST",
+        "/tables",
+        Json.obj("name" -> "categories", "type" -> "taxonomy", "displayName" -> Json.obj("de" -> "Tax"))
+      )
+    } yield result.getLong("id")
+  }
+
+  def fetchTable(tableId: TableId) = sendRequest("GET", s"/completetable/$tableId")
+
+  @Test
+  def createTaxonomyTable(implicit c: TestContext) = okTest {
+    def expectedTable = Json.obj(
+      "name" -> "categories",
+      "type" -> "taxonomy",
+      "displayName" -> Json.obj("de" -> "Tax"),
+      "columns" -> Json.arr(
+          Json.obj("name" -> "title", "kind" -> "shorttext"),
+          Json.obj("name" -> "ordering", "kind" -> "numeric"),
+          Json.obj("name" -> "code", "kind" -> "shorttext"),
+          Json.obj("name" -> "parent", "kind" -> "link")
+        ),
+        "rows" -> Json.emptyArr()
+    )
+    for {
+      tableId <- initTable()
+      table <- fetchTable(tableId)
+    } yield {
+      assertJSONEquals(expectedTable, table)
+    }
+  }
+
+  @Test
+  def changeTitleColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/1", Json.obj ("name" -> "anything"))
+    } yield ()
+  }
+  @Test
+  def changeOrderingColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/2", Json.obj ("name" -> "anything"))
+    } yield ()
+  }
+  @Test
+  def changeCodeColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/3", Json.obj ("name" -> "anything"))
+    } yield ()
+  }
+  @Test
+  def changeLinkColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("POST", s"/tables/$tableId/columns/4", Json.obj ("name" -> "anything"))
+    } yield ()
+  }
+
+  @Test
+  def deleteTitleColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("DELETE", s"/tables/$tableId/columns/1")
+    } yield ()
+  }
+  @Test
+  def deleteOrderingColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("DELETE", s"/tables/$tableId/columns/2")
+    } yield ()
+  }
+  @Test
+  def deleteCodeColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("DELETE", s"/tables/$tableId/columns/3")
+    } yield ()
+  }
+  @Test
+  def deleteLinkColumn (implicit c: TestContext) = exceptionTest("error.request.forbidden.column") {
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("DELETE", s"/tables/$tableId/columns/4")
+    } yield ()
+  }
+
+  @Test
+  def addOptionalColumn(implicit c: TestContext) = okTest {
+    def expectedTable = Json.obj(
+      "name" -> "categories",
+      "type" -> "taxonomy",
+      "displayName" -> Json.obj("de" -> "Tax"),
+      "columns" -> Json.arr(
+          Json.obj("name" -> "title", "kind" -> "shorttext"),
+          Json.obj("name" -> "ordering", "kind" -> "numeric"),
+          Json.obj("name" -> "code", "kind" -> "shorttext"),
+          Json.obj("name" -> "parent", "kind" -> "link"),
+          Json.obj ("name" -> "fifth-column", "kind" -> "text")
+        ),
+        "rows" -> Json.emptyArr()
+    )
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("POST",  s"/tables/$tableId/columns", Json.obj("name" -> "fifth-column", "kind" -> "text"))
+      table <- fetchTable(tableId)
+    } yield {
+      assertJSONEquals(expectedTable, table)
+    }
+  }
+
+  @Test
+  def changeOptionalColumn(implicit c: TestContext) = okTest {
+    def expectedTable = Json.obj(
+      "name" -> "categories",
+      "type" -> "taxonomy",
+      "displayName" -> Json.obj("de" -> "Tax"),
+      "columns" -> Json.arr(
+          Json.obj("name" -> "title", "kind" -> "shorttext"),
+          Json.obj("name" -> "ordering", "kind" -> "numeric"),
+          Json.obj("name" -> "code", "kind" -> "shorttext"),
+          Json.obj("name" -> "parent", "kind" -> "link"),
+          Json.obj ("name" -> "fifth-columbia", "kind" -> "text")
+        ),
+        "rows" -> Json.emptyArr()
+    )
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("POST",  s"/tables/$tableId/columns", Json.obj("name" -> "fifth-column", "kind" -> "text"))
+      _ <- sendRequest("POST",  s"/tables/$tableId/columns/5", Json.obj("name" -> "fifth-columbia"))
+      table <- fetchTable(tableId)
+    } yield {
+      assertJSONEquals(expectedTable, table)
+    }
+  }
+
+  @Test
+  def deleteOptionalColumn(implicit c: TestContext) = okTest {
+    def expectedTable = Json.obj(
+      "name" -> "categories",
+      "type" -> "taxonomy",
+      "displayName" -> Json.obj("de" -> "Tax"),
+      "columns" -> Json.arr(
+          Json.obj("name" -> "title", "kind" -> "shorttext"),
+          Json.obj("name" -> "ordering", "kind" -> "numeric"),
+          Json.obj("name" -> "code", "kind" -> "shorttext"),
+          Json.obj("name" -> "parent", "kind" -> "link"),
+        ),
+        "rows" -> Json.emptyArr()
+    )
+    for {
+      tableId <- initTable()
+      _ <- sendRequest("POST",  s"/tables/$tableId/columns", Json.obj("name" -> "fifth-column", "kind" -> "text"))
+      _ <- sendRequest("DELETE",  s"/tables/$tableId/columns/5")
+      table <- fetchTable(tableId)
+    } yield {
+      assertJSONEquals(expectedTable, table)
+    }
+  }
+}

--- a/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/TaxonomyTableTest.scala
@@ -155,7 +155,7 @@ class TaxonomyTableTest extends TableauxTestBase {
       "type" -> "taxonomy",
       "displayName" -> Json.obj("de" -> "Tax"),
       "columns" -> Json.arr(
-        Json.obj("name" -> "title", "kind" -> "shorttext"),
+        Json.obj("name" -> "name", "kind" -> "shorttext"),
         Json.obj("name" -> "ordering", "kind" -> "numeric"),
         Json.obj("name" -> "code", "kind" -> "shorttext"),
         Json.obj("name" -> "parent", "kind" -> "link"),
@@ -186,7 +186,7 @@ class TaxonomyTableTest extends TableauxTestBase {
       "type" -> "taxonomy",
       "displayName" -> Json.obj("de" -> "Tax"),
       "columns" -> Json.arr(
-        Json.obj("name" -> "title", "kind" -> "shorttext"),
+        Json.obj("name" -> "name", "kind" -> "shorttext"),
         Json.obj("name" -> "ordering", "kind" -> "numeric"),
         Json.obj("name" -> "code", "kind" -> "shorttext"),
         Json.obj("name" -> "parent", "kind" -> "link")


### PR DESCRIPTION
A taxonomy table always has the following immutable columns:

1. title (shorttext, multilang, identifier)
2. ordering (numeric)
3. code (shorttext)
4. parent (link to same table)

It is allowed to add, modify, or delete additional columns.