### PR TITLE
Feature/limit text length

### DIFF
--- a/src/main/resources/schema/schema_v33.sql
+++ b/src/main/resources/schema/schema_v33.sql
@@ -1,0 +1,3 @@
+ALTER TABLE system_columns
+  ADD COLUMN max_length INTEGER DEFAULT NULL,
+  ADD COLUMN min_length INTEGER DEFAULT NULL

--- a/src/main/scala/com/campudus/tableaux/arguments.scala
+++ b/src/main/scala/com/campudus/tableaux/arguments.scala
@@ -109,6 +109,27 @@ object ArgumentChecker {
     }
   }
 
+  def isDefined(options: Seq[Option[_]], trys: Seq[Try[Option[_]]], name: String): ArgumentCheck[Unit] = {
+    val empty = !options.exists(_.isDefined)
+    val noneHaveBeenDefined = trys.forall(_.isFailure)
+
+    if (empty && noneHaveBeenDefined) {
+      FailArg(InvalidRequestException(s"None of these options has a (valid) value. ($name)"))
+    } else {
+      OkArg(())
+    }
+
+  }
+
+  def nullableValuesAreDefined(trys: Seq[Try[Option[_]]], name: String = ""): ArgumentCheck[Unit] = {
+    val allHaveBeenSupplied = trys.forall(_.isSuccess)
+    if (allHaveBeenSupplied) {
+      FailArg(InvalidRequestException(s"None of these options has a (valid) value. ($name)"))
+    } else {
+      OkArg(())
+    }
+  }
+
   def oneOf[A](x: => A, list: List[A], name: String): ArgumentCheck[A] = {
     if (list.contains(x)) {
       OkArg(x)

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -453,17 +453,38 @@ class StructureController(
       separator: Option[Boolean],
       attributes: Option[JsonObject],
       rules: Option[JsonArray],
-      hidden: Option[Boolean]
+      hidden: Option[Boolean],
+      maxLengthTry: Try[Option[Int]],
+      minLengthTry: Try[Option[Int]]
   )(implicit user: TableauxUser): Future[ColumnType[_]] = {
     checkArguments(
       greaterZero(tableId),
       greaterZero(columnId),
       isDefined(
-        Seq(columnName, ordering, kind, identifier, displayInfos, countryCodes, separator, attributes, rules, hidden),
-        "name, ordering, kind, identifier, displayInfos, countryCodes, separator, attributes, rules, hidden"
+        Seq(
+          columnName,
+          ordering,
+          kind,
+          identifier,
+          displayInfos,
+          countryCodes,
+          separator,
+          attributes,
+          rules,
+          hidden
+        ),
+        Seq(maxLengthTry, minLengthTry),
+        "name, ordering, kind, identifier, displayInfos, countryCodes, separator, attributes, rules, hidden, maxLength, minLength"
       )
     )
-
+    val maxLength = maxLengthTry match {
+      case Failure(exception) => None
+      case Success(opt) => opt
+    }
+    val minLength = minLengthTry match {
+      case Failure(exception) => None
+      case Success(opt) => opt
+    }
     val structureProperties: Seq[Option[Any]] = Seq(columnName, ordering, kind, identifier, countryCodes)
     val isAtLeastOneStructureProperty: Boolean = structureProperties.exists(_.isDefined)
 
@@ -487,7 +508,9 @@ class StructureController(
           separator,
           attributes,
           rules,
-          hidden
+          hidden,
+          maxLength,
+          minLength
         )
 
     for {

--- a/src/main/scala/com/campudus/tableaux/database/domain/column.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/column.scala
@@ -35,6 +35,8 @@ sealed trait ColumnInformation {
   val separator: Boolean
   val attributes: JsonObject
   val hidden: Boolean
+  val maxLength: Option[Int]
+  val minLength: Option[Int]
 }
 
 object BasicColumnInformation {
@@ -60,7 +62,9 @@ object BasicColumnInformation {
       Seq.empty,
       createColumn.separator,
       attributes,
-      createColumn.hidden
+      createColumn.hidden,
+      createColumn.maxLength,
+      createColumn.minLength
     )
   }
 }
@@ -104,7 +108,9 @@ case class BasicColumnInformation(
     override val groupColumnIds: Seq[ColumnId],
     override val separator: Boolean,
     override val attributes: JsonObject,
-    override val hidden: Boolean
+    override val hidden: Boolean,
+    override val maxLength: Option[Int],
+    override val minLength: Option[Int]
 ) extends ColumnInformation
 
 case class StatusColumnInformation(
@@ -118,7 +124,9 @@ case class StatusColumnInformation(
     override val separator: Boolean,
     override val attributes: JsonObject,
     val rules: JsonArray,
-    override val hidden: Boolean
+    override val hidden: Boolean,
+    override val maxLength: Option[Int] = None,
+    override val minLength: Option[Int] = None
 ) extends ColumnInformation
 
 case class ConcatColumnInformation(override val table: Table) extends ColumnInformation {
@@ -137,6 +145,8 @@ case class ConcatColumnInformation(override val table: Table) extends ColumnInfo
   override val separator: Boolean = false
   override val hidden: Boolean = false
   override val attributes: JsonObject = Json.obj()
+  override val maxLength: Option[Int] = None
+  override val minLength: Option[Int] = None
 }
 
 object ColumnType {
@@ -398,6 +408,18 @@ case class TextColumn(override val languageType: LanguageType)(override val colu
 ) extends SimpleValueColumn[String](TextType)(languageType) {
 
   override def checkValidSingleValue[B](value: B): Try[String] = Try(value.asInstanceOf[String])
+
+  override def getJson: JsonObject = {
+    val maxLength = columnInformation.maxLength match {
+      case None => null
+      case Some(num) => num
+    }
+    val minLength = columnInformation.minLength match {
+      case None => null
+      case Some(num) => num
+    }
+    super.getJson.mergeIn(Json.obj("maxLength" -> maxLength, "minLength" -> minLength))
+  }
 }
 
 case class ShortTextColumn(override val languageType: LanguageType)(override val columnInformation: ColumnInformation)(
@@ -406,6 +428,18 @@ case class ShortTextColumn(override val languageType: LanguageType)(override val
 ) extends SimpleValueColumn[String](ShortTextType)(languageType) {
 
   override def checkValidSingleValue[B](value: B): Try[String] = Try(value.asInstanceOf[String])
+
+  override def getJson: JsonObject = {
+    val maxLength = columnInformation.maxLength match {
+      case None => null
+      case Some(num) => num
+    }
+    val minLength = columnInformation.minLength match {
+      case None => null
+      case Some(num) => num
+    }
+    super.getJson.mergeIn(Json.obj("maxLength" -> maxLength, "minLength" -> minLength))
+  }
 }
 
 case class RichTextColumn(override val languageType: LanguageType)(override val columnInformation: ColumnInformation)(
@@ -414,6 +448,18 @@ case class RichTextColumn(override val languageType: LanguageType)(override val 
 ) extends SimpleValueColumn[String](RichTextType)(languageType) {
 
   override def checkValidSingleValue[B](value: B): Try[String] = Try(value.asInstanceOf[String])
+
+  override def getJson: JsonObject = {
+    val maxLength = columnInformation.maxLength match {
+      case None => null
+      case Some(num) => num
+    }
+    val minLength = columnInformation.minLength match {
+      case None => null
+      case Some(num) => num
+    }
+    super.getJson.mergeIn(Json.obj("maxLength" -> maxLength, "minLength" -> minLength))
+  }
 }
 
 case class NumberColumn(override val languageType: LanguageType)(override val columnInformation: ColumnInformation)(

--- a/src/main/scala/com/campudus/tableaux/database/domain/createcolumn.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/createcolumn.scala
@@ -15,6 +15,8 @@ sealed trait CreateColumn {
   val separator: Boolean
   val attributes: Option[JsonObject]
   val hidden: Boolean
+  val maxLength: Option[Int] = None
+  val minLength: Option[Int] = None
 }
 
 case class CreateSimpleColumn(
@@ -26,7 +28,9 @@ case class CreateSimpleColumn(
     override val displayInfos: Seq[DisplayInfo],
     override val separator: Boolean,
     override val attributes: Option[JsonObject],
-    override val hidden: Boolean = false
+    override val hidden: Boolean = false,
+    override val maxLength: Option[Int] = None,
+    override val minLength: Option[Int] = None
 ) extends CreateColumn
 
 case class CreateBackLinkColumn(

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -158,7 +158,8 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
     setupVersion(readSchemaFile("schema_v29"), 29),
     setupVersion(readSchemaFile("schema_v30"), 30),
     setupVersion(readSchemaFile("schema_v31"), 31),
-    setupVersion(readSchemaFile("schema_v32"), 32)
+    setupVersion(readSchemaFile("schema_v32"), 32),
+    setupVersion(readSchemaFile("schema_v33"), 33)
   )
 
   private def readSchemaFile(name: String): String = {

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -549,48 +549,47 @@ class TableauxModel(
 
   private def checkValueLengthOfTextCell[A](column: ColumnType[_], value: A): Future[Unit] = {
 
-    val getLengthLimitAttributes: (ColumnType[_]) => (Try[Integer], Try[Integer]) = (column) => {
-      val attributes = column.attributes
-      val minLength = Try(attributes.getJsonObject("minLength").getInteger("value"))
-      val maxLength = Try(attributes.getJsonObject("maxLength").getInteger("value"))
+    val getLengthLimitAttributes: (ColumnType[_]) => (Option[Int], Option[Int]) = (column) => {
+      val minLength = column.columnInformation.minLength
+      val maxLength = column.columnInformation.maxLength
       (minLength, maxLength)
     }
 
-    val checkMultiLangLength: (Integer => Boolean, JsonObject) => Boolean = (op, multiLangValue) => {
+    val checkMultiLangLength: (Int => Boolean, JsonObject) => Boolean = (op, multiLangValue) => {
       val map: mutable.Map[String, AnyRef] = multiLangValue.getMap.asScala
       map.values.map(value => value.asInstanceOf[String]).forall(value => value.length() == 0 || op(value.length()))
     }
 
-    val checkSimpleLangLength: (Integer => Boolean, String) => Boolean =
+    val checkSimpleLangLength: (Int => Boolean, String) => Boolean =
       (op, value) => {
         value.length() == 0 || op(value.length())
       }
 
-    val checkLength: (Integer => Boolean, Boolean, A) => Boolean = (op, isMultilang, value) => {
+    val checkLength: (Int => Boolean, Boolean, A) => Boolean = (op, isMultilang, value) => {
       isMultilang match {
         case false => checkSimpleLangLength(op, value.asInstanceOf[String])
         case true => checkMultiLangLength(op, value.asInstanceOf[JsonObject])
       }
     }
 
-    val checkValueLength: ((Try[Integer], Try[Integer]), A) => Future[Unit] = (maybeLengthLimits, value) => {
+    val checkValueLength: ((Option[Int], Option[Int]), A) => Future[Unit] = (maybeLengthLimits, value) => {
       val (maybeMinLength, maybeMaxLength) = maybeLengthLimits
       val columnIsMultilanguage = column.languageType == MultiLanguage
       val asBool = maybeLengthLimits match {
-        case (Success(minLength), Success(maxLength)) => {
+        case (Some(minLength), Some(maxLength)) => {
           checkLength(minLength <= _, columnIsMultilanguage, value) && checkLength(
             maxLength >= _,
             columnIsMultilanguage,
             value
           )
         }
-        case (Failure(_), Success(maxLength)) => {
+        case (None, Some(maxLength)) => {
           checkLength(maxLength >= _, columnIsMultilanguage, value)
         }
-        case (Success(minLength), Failure(_)) => {
+        case (Some(minLength), None) => {
           checkLength(minLength <= _, columnIsMultilanguage, value)
         }
-        case (Failure(_), Failure(_)) => {
+        case (None, None) => {
           true
         }
       }

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -563,8 +563,8 @@ class TableauxModel(
     }
 
     val checkSimpleLangLength: (Int => Boolean, String) => Boolean =
-      (op, value) => {
-        value.length() == 0 || op(value.length())
+      (compareFunc, value) => {
+        value.length() == 0 || compareFunc(value.length())
       }
 
     val checkLength: (Int => Boolean, Boolean, A) => Boolean = (compareFunc, isMultilang, value) => {

--- a/src/main/scala/com/campudus/tableaux/exceptions.scala
+++ b/src/main/scala/com/campudus/tableaux/exceptions.scala
@@ -164,3 +164,9 @@ case class HasStatusColumnDependencyException(override val message: String) exte
   override val id: String = s"error.column.dependency"
   override val statusCode: Int = 409
 }
+
+case class LengthOutOfRangeException() extends CustomException {
+  override val id: String = s"error.request.value.length"
+  override val statusCode: Int = 500
+  override val message: String = "Value length is not in specified range."
+}

--- a/src/main/scala/com/campudus/tableaux/exceptions.scala
+++ b/src/main/scala/com/campudus/tableaux/exceptions.scala
@@ -173,6 +173,6 @@ case class HasStatusColumnDependencyException(override val message: String) exte
 
 case class LengthOutOfRangeException() extends CustomException {
   override val id: String = s"error.request.value.length"
-  override val statusCode: Int = 500
+  override val statusCode: Int = 400
   override val message: String = "Value length is not in specified range."
 }

--- a/src/main/scala/com/campudus/tableaux/exceptions.scala
+++ b/src/main/scala/com/campudus/tableaux/exceptions.scala
@@ -27,6 +27,12 @@ sealed trait CustomException extends Throwable {
   )
 }
 
+case class KeyNotFoundInJsonException(key: String) extends CustomException {
+  override val id = "error.json.key.notfound"
+  override val statusCode = 400
+  val message = s"Key $key not found"
+}
+
 case class NoJsonFoundException(override val message: String) extends CustomException {
   override val id = "error.json.notfound"
   override val statusCode = 400

--- a/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
@@ -271,7 +271,9 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
             optSeparator,
             optAttributes,
             optRules,
-            optHidden
+            optHidden,
+            maxLength,
+            minLength
           ) =
             toColumnChanges(json)
 
@@ -287,7 +289,9 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
             optSeparator,
             optAttributes,
             optRules,
-            optHidden
+            optHidden,
+            maxLength,
+            minLength
           )
         }
       )

--- a/src/test/scala/com/campudus/tableaux/api/auth/StructureControllerAuthTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/auth/StructureControllerAuthTest.scala
@@ -15,6 +15,8 @@ import io.vertx.ext.unit.junit.VertxUnitRunner
 import io.vertx.scala.SQLConnection
 import org.vertx.scala.core.json.{Json, JsonObject}
 
+import scala.util.{Failure, Success, Try}
+
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -541,7 +543,22 @@ class StructureControllerColumnAuthTest_checkAuthorization extends StructureCont
 
     for {
       tableId <- createDefaultTable("Test")
-      _ <- controller.changeColumn(tableId, 1, None, None, None, None, Some(displayInfos), None, None, None, None, None)
+      _ <- controller.changeColumn(
+        tableId,
+        1,
+        None,
+        None,
+        None,
+        None,
+        Some(displayInfos),
+        None,
+        None,
+        None,
+        None,
+        None,
+        Try(Option(0)),
+        Try(Option(0))
+      )
     } yield ()
   }
 
@@ -554,7 +571,22 @@ class StructureControllerColumnAuthTest_checkAuthorization extends StructureCont
       for {
         tableId <- createDefaultTable("Test")
         _ <-
-          controller.changeColumn(tableId, 1, None, None, None, None, Some(displayInfos), None, None, None, None, None)
+          controller.changeColumn(
+            tableId,
+            1,
+            None,
+            None,
+            None,
+            None,
+            Some(displayInfos),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Try(Option(0)),
+            Try(Option(0))
+          )
       } yield ()
     }
 
@@ -580,7 +612,22 @@ class StructureControllerColumnAuthTest_checkAuthorization extends StructureCont
     for {
       tableId <- createDefaultTable("Test")
       _ <- controller
-        .changeColumn(tableId, 1, Some("newName"), None, None, None, Some(displayInfos), None, None, None, None, None)
+        .changeColumn(
+          tableId,
+          1,
+          Some("newName"),
+          None,
+          None,
+          None,
+          Some(displayInfos),
+          None,
+          None,
+          None,
+          None,
+          None,
+          Try(Option(0)),
+          Try(Option(0))
+        )
     } yield ()
   }
 
@@ -593,7 +640,22 @@ class StructureControllerColumnAuthTest_checkAuthorization extends StructureCont
       for {
         tableId <- createDefaultTable("Test")
         _ <- controller
-          .changeColumn(tableId, 1, Some("newName"), None, None, None, Some(displayInfos), None, None, None, None, None)
+          .changeColumn(
+            tableId,
+            1,
+            Some("newName"),
+            None,
+            None,
+            None,
+            Some(displayInfos),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Try(Option(0)),
+            Try(Option(0))
+          )
       } yield ()
     }
 
@@ -640,10 +702,27 @@ class StructureControllerColumnAuthTest_checkAuthorization extends StructureCont
           None,
           None,
           None,
-          None
+          None,
+          Try(Option(0)),
+          Try(Option(0))
         )
         ex <- controller
-          .changeColumn(variantTableId, 1, Some("newName"), None, None, None, None, None, None, None, None, None)
+          .changeColumn(
+            variantTableId,
+            1,
+            Some("newName"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Try(Option(0)),
+            Try(Option(0))
+          )
           .recover({ case ex => ex })
       } yield {
         assertEquals(UnauthorizedException(EditColumnStructureProperty, Seq("edit-columns-in-model-tables")), ex)

--- a/src/test/scala/com/campudus/tableaux/api/content/FillCellTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/FillCellTest.scala
@@ -81,32 +81,16 @@ class FillCellTest extends TableauxTestBase {
     val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
       "kind" -> "text",
       "name" -> "Test Column 1",
-      "attributes" -> Json.obj(
-        "minLength" -> Json.obj(
-          "value" -> 5,
-          "type" -> "number"
-        ),
-        "maxLength" -> Json.obj(
-          "value" -> 10,
-          "type" -> "number"
-        )
-      )
+      "minLength" -> 5,
+      "maxLength" -> 10
     )))
 
     val createMultilangStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
       "kind" -> "text",
       "name" -> "Test Column 2",
       "multilanguage" -> true,
-      "attributes" -> Json.obj(
-        "minLength" -> Json.obj(
-          "value" -> 5,
-          "type" -> "number"
-        ),
-        "maxLength" -> Json.obj(
-          "value" -> 10,
-          "type" -> "number"
-        )
-      )
+      "minLength" -> 5,
+      "maxLength" -> 10
     )))
 
     for {
@@ -139,32 +123,16 @@ class FillCellTest extends TableauxTestBase {
     val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
       "kind" -> "text",
       "name" -> "Test Column 1",
-      "attributes" -> Json.obj(
-        "minLength" -> Json.obj(
-          "value" -> 5,
-          "type" -> "number"
-        ),
-        "maxLength" -> Json.obj(
-          "value" -> 10,
-          "type" -> "number"
-        )
-      )
+      "minLength" -> 5,
+      "maxLength" -> 10
     )))
 
     val createMultilangStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
       "kind" -> "text",
       "name" -> "Test Column 2",
       "multilanguage" -> true,
-      "attributes" -> Json.obj(
-        "minLength" -> Json.obj(
-          "value" -> 5,
-          "type" -> "number"
-        ),
-        "maxLength" -> Json.obj(
-          "value" -> 10,
-          "type" -> "number"
-        )
-      )
+      "minLength" -> 5,
+      "maxLength" -> 10
     )))
 
     for {
@@ -192,16 +160,8 @@ class FillCellTest extends TableauxTestBase {
       val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
         "kind" -> "text",
         "name" -> "Test Column 1",
-        "attributes" -> Json.obj(
-          "minLength" -> Json.obj(
-            "value" -> 5,
-            "type" -> "number"
-          ),
-          "maxLength" -> Json.obj(
-            "value" -> 10,
-            "type" -> "number"
-          )
-        )
+        "minLength" -> 5,
+        "maxLength" -> 10
       )))
 
       for {
@@ -221,16 +181,8 @@ class FillCellTest extends TableauxTestBase {
         "kind" -> "text",
         "name" -> "Test Column 1",
         "multilanguage" -> true,
-        "attributes" -> Json.obj(
-          "minLength" -> Json.obj(
-            "value" -> 5,
-            "type" -> "number"
-          ),
-          "maxLength" -> Json.obj(
-            "value" -> 10,
-            "type" -> "number"
-          )
-        )
+        "minLength" -> 5,
+        "maxLength" -> 10
       )))
 
       for {
@@ -250,16 +202,8 @@ class FillCellTest extends TableauxTestBase {
         "kind" -> "text",
         "name" -> "Test Column 1",
         "multilanguage" -> true,
-        "attributes" -> Json.obj(
-          "minLength" -> Json.obj(
-            "value" -> 5,
-            "type" -> "number"
-          ),
-          "maxLength" -> Json.obj(
-            "value" -> 10,
-            "type" -> "number"
-          )
-        )
+        "minLength" -> 5,
+        "maxLength" -> 10
       )))
 
       for {
@@ -280,16 +224,8 @@ class FillCellTest extends TableauxTestBase {
       val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
         "kind" -> "text",
         "name" -> "Test Column 1",
-        "attributes" -> Json.obj(
-          "minLength" -> Json.obj(
-            "value" -> 5,
-            "type" -> "number"
-          ),
-          "maxLength" -> Json.obj(
-            "value" -> 10,
-            "type" -> "number"
-          )
-        )
+        "minLength" -> 5,
+        "maxLength" -> 10
       )))
 
       for {

--- a/src/test/scala/com/campudus/tableaux/api/content/FillCellTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/FillCellTest.scala
@@ -155,8 +155,6 @@ class FillCellTest extends TableauxTestBase {
     exceptionTest("error.request.value.length") {
       val fillStringCellJson1 = Json.obj("value" -> "1234")
 
-      val expectedCell1 = Json.obj("status" -> "ok", "value" -> "12345")
-
       val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
         "kind" -> "text",
         "name" -> "Test Column 1",
@@ -218,8 +216,6 @@ class FillCellTest extends TableauxTestBase {
   def fillSingleStringCellWithLengthTooLong(implicit c: TestContext): Unit =
     exceptionTest("error.request.value.length") {
       val fillStringCellJson1 = Json.obj("value" -> "012345678921")
-
-      val expectedCell1 = Json.obj("status" -> "ok", "value" -> "12345")
 
       val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
         "kind" -> "text",

--- a/src/test/scala/com/campudus/tableaux/api/content/FillCellTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/FillCellTest.scala
@@ -67,6 +67,240 @@ class FillCellTest extends TableauxTestBase {
   }
 
   @Test
+  def fillStringCellWithLengthInRange(implicit c: TestContext): Unit = okTest {
+    val fillStringCellJson1 = Json.obj("value" -> "12345")
+    val fillStringCellJson2 = Json.obj("value" -> "1234567")
+    val fillStringCellJson3 = Json.obj("value" -> "0123456789")
+    val fillStringCellJson4 = Json.obj("value" -> Json.obj("de" -> "12345", "en" -> "0123456789"))
+
+    val expectedCell1 = Json.obj("status" -> "ok", "value" -> "12345")
+    val expectedCell2 = Json.obj("status" -> "ok", "value" -> "1234567")
+    val expectedCell3 = Json.obj("status" -> "ok", "value" -> "0123456789")
+    val expectedCell4 = Json.obj("status" -> "ok", "value" -> Json.obj("de" -> "12345", "en" -> "0123456789"))
+
+    val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
+      "kind" -> "text",
+      "name" -> "Test Column 1",
+      "attributes" -> Json.obj(
+        "minLength" -> Json.obj(
+          "value" -> 5,
+          "type" -> "number"
+        ),
+        "maxLength" -> Json.obj(
+          "value" -> 10,
+          "type" -> "number"
+        )
+      )
+    )))
+
+    val createMultilangStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
+      "kind" -> "text",
+      "name" -> "Test Column 2",
+      "multilanguage" -> true,
+      "attributes" -> Json.obj(
+        "minLength" -> Json.obj(
+          "value" -> 5,
+          "type" -> "number"
+        ),
+        "maxLength" -> Json.obj(
+          "value" -> 10,
+          "type" -> "number"
+        )
+      )
+    )))
+
+    for {
+      _ <- sendRequest("POST", "/tables", createTableJson)
+      _ <- sendRequest("POST", "/tables/1/columns", createStringColumnJsonWithLengthLimit)
+      _ <- sendRequest("POST", "/tables/1/columns", createMultilangStringColumnJsonWithLengthLimit)
+      _ <- sendRequest("POST", "/tables/1/rows")
+      res1 <- sendRequest("POST", "/tables/1/columns/1/rows/1", fillStringCellJson1)
+      res2 <- sendRequest("POST", "/tables/1/columns/1/rows/1", fillStringCellJson2)
+      res3 <- sendRequest("POST", "/tables/1/columns/1/rows/1", fillStringCellJson3)
+      res4 <- sendRequest("POST", "/tables/1/columns/2/rows/1", fillStringCellJson4)
+    } yield {
+      assertEquals(expectedCell1, res1)
+      assertEquals(expectedCell2, res2)
+      assertEquals(expectedCell3, res3)
+      assertEquals(expectedCell4, res4)
+    }
+  }
+
+  @Test
+  def emptyStringCellWithLimitsPresent(implicit c: TestContext): Unit = okTest {
+    val fillStringCellJson1 = Json.obj("value" -> "12345")
+    val fillStringCellJson2 = Json.obj("value" -> "")
+    val fillStringCellJson3 = Json.obj("value" -> Json.obj("de" -> "123456", "en" -> "0123456789"))
+    val fillStringCellJson4 = Json.obj("value" -> Json.obj("de" -> "", "en" -> "0123456789"))
+
+    val expectedCell2 = Json.obj("status" -> "ok", "value" -> "")
+    val expectedCell4 = Json.obj("status" -> "ok", "value" -> Json.obj("de" -> "", "en" -> "0123456789"))
+
+    val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
+      "kind" -> "text",
+      "name" -> "Test Column 1",
+      "attributes" -> Json.obj(
+        "minLength" -> Json.obj(
+          "value" -> 5,
+          "type" -> "number"
+        ),
+        "maxLength" -> Json.obj(
+          "value" -> 10,
+          "type" -> "number"
+        )
+      )
+    )))
+
+    val createMultilangStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
+      "kind" -> "text",
+      "name" -> "Test Column 2",
+      "multilanguage" -> true,
+      "attributes" -> Json.obj(
+        "minLength" -> Json.obj(
+          "value" -> 5,
+          "type" -> "number"
+        ),
+        "maxLength" -> Json.obj(
+          "value" -> 10,
+          "type" -> "number"
+        )
+      )
+    )))
+
+    for {
+      _ <- sendRequest("POST", "/tables", createTableJson)
+      _ <- sendRequest("POST", "/tables/1/columns", createStringColumnJsonWithLengthLimit)
+      _ <- sendRequest("POST", "/tables/1/columns", createMultilangStringColumnJsonWithLengthLimit)
+      _ <- sendRequest("POST", "/tables/1/rows")
+      res1 <- sendRequest("POST", "/tables/1/columns/1/rows/1", fillStringCellJson1)
+      res2 <- sendRequest("POST", "/tables/1/columns/1/rows/1", fillStringCellJson2)
+      res3 <- sendRequest("POST", "/tables/1/columns/2/rows/1", fillStringCellJson3)
+      res4 <- sendRequest("POST", "/tables/1/columns/2/rows/1", fillStringCellJson4)
+    } yield {
+      assertEquals(expectedCell2, res2)
+      assertEquals(expectedCell4, res4)
+    }
+  }
+
+  @Test
+  def fillSingleStringCellWithLengthTooShort(implicit c: TestContext): Unit =
+    exceptionTest("error.request.value.length") {
+      val fillStringCellJson1 = Json.obj("value" -> "1234")
+
+      val expectedCell1 = Json.obj("status" -> "ok", "value" -> "12345")
+
+      val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
+        "kind" -> "text",
+        "name" -> "Test Column 1",
+        "attributes" -> Json.obj(
+          "minLength" -> Json.obj(
+            "value" -> 5,
+            "type" -> "number"
+          ),
+          "maxLength" -> Json.obj(
+            "value" -> 10,
+            "type" -> "number"
+          )
+        )
+      )))
+
+      for {
+        _ <- sendRequest("POST", "/tables", createTableJson)
+        col <- sendRequest("POST", "/tables/1/columns", createStringColumnJsonWithLengthLimit)
+        _ <- sendRequest("POST", "/tables/1/rows")
+        res1 <- sendRequest("POST", "/tables/1/columns/1/rows/1", fillStringCellJson1)
+      } yield ()
+    }
+
+  @Test
+  def fillMultilangStringCellWithLengthTooShort(implicit c: TestContext): Unit =
+    exceptionTest("error.request.value.length") {
+      val fillStringCellJson1 = Json.obj("value" -> Json.obj("de" -> "123", "en" -> "123456"))
+
+      val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
+        "kind" -> "text",
+        "name" -> "Test Column 1",
+        "multilanguage" -> true,
+        "attributes" -> Json.obj(
+          "minLength" -> Json.obj(
+            "value" -> 5,
+            "type" -> "number"
+          ),
+          "maxLength" -> Json.obj(
+            "value" -> 10,
+            "type" -> "number"
+          )
+        )
+      )))
+
+      for {
+        _ <- sendRequest("POST", "/tables", createTableJson)
+        col <- sendRequest("POST", "/tables/1/columns", createStringColumnJsonWithLengthLimit)
+        _ <- sendRequest("POST", "/tables/1/rows")
+        res1 <- sendRequest("POST", "/tables/1/columns/1/rows/1", fillStringCellJson1)
+      } yield ()
+    }
+
+  @Test
+  def fillMultilangStringCellWithLengthTooLong(implicit c: TestContext): Unit =
+    exceptionTest("error.request.value.length") {
+      val fillStringCellJson1 = Json.obj("value" -> Json.obj("de" -> "12345678912345", "en" -> "123456"))
+
+      val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
+        "kind" -> "text",
+        "name" -> "Test Column 1",
+        "multilanguage" -> true,
+        "attributes" -> Json.obj(
+          "minLength" -> Json.obj(
+            "value" -> 5,
+            "type" -> "number"
+          ),
+          "maxLength" -> Json.obj(
+            "value" -> 10,
+            "type" -> "number"
+          )
+        )
+      )))
+
+      for {
+        _ <- sendRequest("POST", "/tables", createTableJson)
+        col <- sendRequest("POST", "/tables/1/columns", createStringColumnJsonWithLengthLimit)
+        _ <- sendRequest("POST", "/tables/1/rows")
+        res1 <- sendRequest("POST", "/tables/1/columns/1/rows/1", fillStringCellJson1)
+      } yield ()
+    }
+
+  @Test
+  def fillSingleStringCellWithLengthTooLong(implicit c: TestContext): Unit =
+    exceptionTest("error.request.value.length") {
+      val fillStringCellJson1 = Json.obj("value" -> "012345678921")
+
+      val expectedCell1 = Json.obj("status" -> "ok", "value" -> "12345")
+
+      val createStringColumnJsonWithLengthLimit = Json.obj("columns" -> Json.arr(Json.obj(
+        "kind" -> "text",
+        "name" -> "Test Column 1",
+        "attributes" -> Json.obj(
+          "minLength" -> Json.obj(
+            "value" -> 5,
+            "type" -> "number"
+          ),
+          "maxLength" -> Json.obj(
+            "value" -> 10,
+            "type" -> "number"
+          )
+        )
+      )))
+
+      for {
+        _ <- sendRequest("POST", "/tables", createTableJson)
+        col <- sendRequest("POST", "/tables/1/columns", createStringColumnJsonWithLengthLimit)
+        _ <- sendRequest("POST", "/tables/1/rows")
+        res1 <- sendRequest("POST", "/tables/1/columns/1/rows/1", fillStringCellJson1)
+      } yield ()
+    }
+
+  @Test
   def fillSingleNumberCell(implicit c: TestContext): Unit = okTest {
     val fillNumberCellJson = Json.obj("value" -> 101)
 

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -72,8 +72,8 @@ class SystemControllerTest extends TableauxTestBase {
     okTest {
       val expectedJson = Json.obj(
         "database" -> Json.obj(
-          "current" -> 32,
-          "specification" -> 32
+          "current" -> 33,
+          "specification" -> 33
         )
       )
 


### PR DESCRIPTION
AC-Task: https://app.activecollab.com/116706/projects/2?modal=Task-40283-2
This PR implements a minimum and maximum length check of text-based cells.
The minimum and maximum values can be defined as attributes on column level.
For example:
`{
    "columns": [
        {
            "name": "length_check_multilang",
            "multilanguage": true,
            "kind": "text",
            "attributes": {
                "maxLength": {
                    "value": 10,
                    "type": "number"
                },
                "minLength": {
                    "value": 5,
                    "type": "number"
                }
            }
        }
    ]
}`
In this example values [5...10] are permitted, 5 and 10 included, also, zero length is always permitted.