### PR TITLE
Allow customising row duplication behaviour

### DIFF
--- a/src/main/resources/swagger.json
+++ b/src/main/resources/swagger.json
@@ -10,17 +10,11 @@
     },
     "version": "1.0.0"
   },
-  "schemes": [
-    "$SCHEME$"
-  ],
+  "schemes": ["$SCHEME$"],
   "host": "$HOST$",
   "basePath": "$BASEPATH$",
-  "consumes": [
-    "application/json"
-  ],
-  "produces": [
-    "application/json"
-  ],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
   "externalDocs": {
     "description": "GitHub project",
     "url": "https://github.com/campudus/tableaux"
@@ -44,9 +38,7 @@
       "post": {
         "summary": "Create file handle",
         "description": "Creates a new temporary file handle.",
-        "tags": [
-          "media"
-        ],
+        "tags": ["media"],
         "operationId": "create-file-handle",
         "parameters": [
           {
@@ -56,11 +48,7 @@
             "required": true,
             "schema": {
               "type": "object",
-              "required": [
-                "folder",
-                "description",
-                "title"
-              ],
+              "required": ["folder", "description", "title"],
               "properties": {
                 "folder": {
                   "type": "integer",
@@ -167,9 +155,7 @@
       "get": {
         "summary": "Get file meta-information",
         "description": "Returns meta-information about a file.",
-        "tags": [
-          "media"
-        ],
+        "tags": ["media"],
         "operationId": "get-file-meta-information",
         "responses": {
           "200": {
@@ -183,9 +169,7 @@
       "put": {
         "summary": "Change file meta-information",
         "description": "Changes meta information of file.",
-        "tags": [
-          "media"
-        ],
+        "tags": ["media"],
         "operationId": "change-file-meta-information",
         "parameters": [
           {
@@ -228,9 +212,7 @@
       "delete": {
         "summary": "Delete file",
         "description": "",
-        "tags": [
-          "media"
-        ],
+        "tags": ["media"],
         "operationId": "delete-file",
         "responses": {
           "200": {
@@ -254,9 +236,7 @@
       "put": {
         "summary": "Upload file",
         "description": "Uploads/replaces a language specific file for this file handle.",
-        "tags": [
-          "media"
-        ],
+        "tags": ["media"],
         "operationId": "upload-file",
         "responses": {
           "200": {
@@ -267,9 +247,7 @@
       "delete": {
         "summary": "Delete file (language specific)",
         "description": "",
-        "tags": [
-          "media"
-        ],
+        "tags": ["media"],
         "operationId": "delete-file-language-specific",
         "responses": {
           "200": {
@@ -282,9 +260,7 @@
       "get": {
         "summary": "Get root folder",
         "description": "Returns the root folder. Has no ID because it can't be changed or deleted.",
-        "tags": [
-          "media"
-        ],
+        "tags": ["media"],
         "operationId": "get-root-folder",
         "parameters": [
           {
@@ -313,9 +289,7 @@
       "post": {
         "summary": "Create folder",
         "description": "Creates a new folder.",
-        "tags": [
-          "media"
-        ],
+        "tags": ["media"],
         "operationId": "create-folder",
         "parameters": [
           {
@@ -343,9 +317,7 @@
       "get": {
         "summary": "Get folder",
         "description": "Returns a specific folder. Hierarchy is not relevant.",
-        "tags": [
-          "media"
-        ],
+        "tags": ["media"],
         "operationId": "get-folder",
         "parameters": [
           {
@@ -368,9 +340,7 @@
       "put": {
         "summary": "Change folder",
         "description": "Changes folder.",
-        "tags": [
-          "media"
-        ],
+        "tags": ["media"],
         "operationId": "change-folder",
         "parameters": [
           {
@@ -391,9 +361,7 @@
       "delete": {
         "summary": "Delete folder",
         "description": "",
-        "tags": [
-          "media"
-        ],
+        "tags": ["media"],
         "operationId": "delete-folder",
         "responses": {
           "200": {
@@ -406,9 +374,7 @@
       "post": {
         "summary": "Reset system tables",
         "description": "Resets whole schema and re-initialize system tables",
-        "tags": [
-          "system"
-        ],
+        "tags": ["system"],
         "operationId": "reset-system-tables",
         "parameters": [
           {
@@ -426,9 +392,7 @@
       "post": {
         "summary": "Create demo tables",
         "description": "Creates two demo tables (Bundesländer, Regierungsbezirke) with links.",
-        "tags": [
-          "system"
-        ],
+        "tags": ["system"],
         "operationId": "create-demo-tables",
         "parameters": [
           {
@@ -446,14 +410,10 @@
       "get": {
         "summary": "Get current version",
         "description": "",
-        "tags": [
-          "system"
-        ],
+        "tags": ["system"],
         "operationId": "get-version",
         "consumes": [],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "parameters": [],
         "responses": {
           "200": {
@@ -475,14 +435,10 @@
       "get": {
         "summary": "Get all services",
         "description": "Returns an array containing all available services with their metadata.",
-        "tags": [
-          "system"
-        ],
+        "tags": ["system"],
         "operationId": "get-all-services",
         "consumes": [],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "parameters": [],
         "responses": {
           "200": {
@@ -502,9 +458,7 @@
       "post": {
         "summary": "Create a new service",
         "description": "Creates the service.",
-        "tags": [
-          "system"
-        ],
+        "tags": ["system"],
         "operationId": "create-new-service",
         "parameters": [
           {
@@ -541,9 +495,7 @@
       "get": {
         "summary": "Get service",
         "description": "Returns the metadata of a service.",
-        "tags": [
-          "system"
-        ],
+        "tags": ["system"],
         "operationId": "get-service",
         "responses": {
           "200": {
@@ -560,9 +512,7 @@
       "patch": {
         "summary": "Change service",
         "description": "Changes the service and returns its current metadata.",
-        "tags": [
-          "system"
-        ],
+        "tags": ["system"],
         "operationId": "change-service",
         "parameters": [
           {
@@ -589,9 +539,7 @@
       "delete": {
         "summary": "Delete a service",
         "description": "Drops the complete service and deletes its definition.",
-        "tags": [
-          "system"
-        ],
+        "tags": ["system"],
         "operationId": "delete-service",
         "responses": {
           "200": {
@@ -607,9 +555,7 @@
       "post": {
         "summary": "Update system tables",
         "description": "Updates schema of system tables. To get the nonce, take a look at the backend logs.",
-        "tags": [
-          "system"
-        ],
+        "tags": ["system"],
         "operationId": "update-system-tables",
         "parameters": [
           {
@@ -636,9 +582,7 @@
       "post": {
         "summary": "Create a complete table with columns and rows",
         "description": "Adds the table structure.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "create-new-complete-table",
         "parameters": [
           {
@@ -670,14 +614,10 @@
       "get": {
         "summary": "Get all tables",
         "description": "Returns an array containing all available tables with their metadata.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "get-all-tables",
         "consumes": [],
-        "produces": [
-          "application/json"
-        ],
+        "produces": ["application/json"],
         "parameters": [],
         "responses": {
           "200": {
@@ -697,9 +637,7 @@
       "post": {
         "summary": "Create a new empty table",
         "description": "Adds the table structure.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "create-new-empty-table",
         "parameters": [
           {
@@ -736,9 +674,7 @@
       "get": {
         "summary": "Get table",
         "description": "Returns the metadata of a table.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "get-table",
         "parameters": [
           {
@@ -757,9 +693,7 @@
       "post": {
         "summary": "Change table",
         "description": "Changes the table",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "change-table",
         "parameters": [
           {
@@ -780,9 +714,7 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Drops the complete table and deletes its definition.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "delete-table",
         "responses": {
           "200": {
@@ -803,9 +735,7 @@
       "get": {
         "summary": "Get columns definition",
         "description": "Returns all columns of specific table",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "get-columns-definition",
         "responses": {
           "200": {
@@ -819,9 +749,7 @@
       "post": {
         "summary": "Create new column(s)",
         "description": "Alters the user table and add the column definition to the system table.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "create-new-column",
         "parameters": [
           {
@@ -830,9 +758,7 @@
             "required": false,
             "schema": {
               "type": "array",
-              "required": [
-                "columns"
-              ],
+              "required": ["columns"],
               "properties": {
                 "columns": {
                   "$ref": "#/definitions/Shared Request: Column"
@@ -861,20 +787,14 @@
                       "example": 3
                     }
                   },
-                  "required": [
-                    "id",
-                    "ordering"
-                  ]
+                  "required": ["id", "ordering"]
                 },
                 "status": {
                   "type": "string",
                   "example": "ok"
                 }
               },
-              "required": [
-                "columns",
-                "status"
-              ]
+              "required": ["columns", "status"]
             }
           }
         }
@@ -892,9 +812,7 @@
       "get": {
         "summary": "Get column definition",
         "description": "Returns information about a specific column.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "get-column-definition",
         "responses": {
           "200": {
@@ -908,9 +826,7 @@
       "post": {
         "summary": "Change column",
         "description": "Alters the column definition.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "change-column",
         "parameters": [
           {
@@ -945,9 +861,7 @@
       "delete": {
         "summary": "Delete column",
         "description": "Deletes column from user table and table definition.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "delete-column",
         "responses": {
           "200": {
@@ -960,9 +874,7 @@
       "post": {
         "summary": "Create table group",
         "description": "Creates a table group.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "create-table-group",
         "parameters": [
           {
@@ -990,9 +902,7 @@
       "post": {
         "summary": "Change table group",
         "description": "Changes a table group.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "change-table-group",
         "parameters": [
           {
@@ -1013,9 +923,7 @@
       "delete": {
         "summary": "Delete table group",
         "description": "Deletes a table group.",
-        "tags": [
-          "structure"
-        ],
+        "tags": ["structure"],
         "operationId": "delete-table-group",
         "responses": {
           "200": {
@@ -1042,9 +950,7 @@
       "get": {
         "summary": "Get specific cell value",
         "description": "Returns the value of a specified cell.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "retrieve-cell",
         "responses": {
           "200": {
@@ -1058,9 +964,7 @@
       "post": {
         "summary": "DEPRECATED - Update cell or add link/attachment",
         "description": "DEPRECATED: Use same route with PATCH instead. Updates the value of specified cell. This can add links, attachments, multi-language contents and replaces simple values such as numbers, booleans or strings.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "update-cell-deprecated",
         "parameters": [
           {
@@ -1079,9 +983,7 @@
       "patch": {
         "summary": "Update cell or add link/attachment",
         "description": "Updates the value of specified cell. This can add links, attachments, multi-language contents and replaces simple values such as numbers, booleans or strings.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "update-cell",
         "parameters": [
           {
@@ -1100,9 +1002,7 @@
       "put": {
         "summary": "Replace cell value",
         "description": "Replace the current value of the specified cell. This overwrites all languages in a multi-language cell or deletes all links and replaces the data with the provided value.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "replace-cell",
         "parameters": [
           {
@@ -1121,9 +1021,7 @@
       "delete": {
         "summary": "Remove a cell value.",
         "description": "Clears the set cell value and reset it to its default value.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "clear-cell-value",
         "responses": {
           "200": {
@@ -1150,9 +1048,7 @@
       "get": {
         "summary": "Retrieves the history entries of a table",
         "description": "Returns the history entries of a table.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "retrieve-table-history-cell",
         "responses": {
           "200": {
@@ -1182,9 +1078,7 @@
       "get": {
         "summary": "Retrieves the history entries of a row",
         "description": "Returns the history entries of a row.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "retrieve-row-history-cell",
         "responses": {
           "200": {
@@ -1217,9 +1111,7 @@
       "get": {
         "summary": "Retrieves the history entries of a cell",
         "description": "Returns the history entries of a specified cell.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "retrieve-cell-history-cell",
         "responses": {
           "200": {
@@ -1240,9 +1132,7 @@
       "get": {
         "summary": "Get all rows",
         "description": "Returns just the rows of the table",
-        "tags": [
-          "data"
-        ],
+        "tags": ["data"],
         "operationId": "get-all-rows",
         "responses": {
           "200": {
@@ -1262,9 +1152,7 @@
       "post": {
         "summary": "Create new row",
         "description": "Adds new row to user table.",
-        "tags": [
-          "data"
-        ],
+        "tags": ["data"],
         "operationId": "create-new-row",
         "parameters": [
           {
@@ -1273,10 +1161,7 @@
             "required": false,
             "schema": {
               "type": "object",
-              "required": [
-                "columns",
-                "rows"
-              ],
+              "required": ["columns", "rows"],
               "properties": {
                 "columns": {
                   "type": "array",
@@ -1288,9 +1173,7 @@
                       "description": "Column id"
                     }
                   },
-                  "required": [
-                    "id"
-                  ]
+                  "required": ["id"]
                 },
                 "rows": {
                   "type": "array",
@@ -1338,9 +1221,7 @@
       "get": {
         "summary": "Get single row",
         "description": "Returns a single row and its values.",
-        "tags": [
-          "data"
-        ],
+        "tags": ["data"],
         "operationId": "get-single-row",
         "responses": {
           "200": {
@@ -1354,9 +1235,7 @@
       "delete": {
         "summary": "Delete row",
         "description": "Deletes a row from user table. Optionally, all rows associated with this row can be replaced by a another rowId provided via query parameter `replacingRowId`",
-        "tags": [
-          "data"
-        ],
+        "tags": ["data"],
         "operationId": "delete-row",
         "parameters": [
           {
@@ -1380,11 +1259,44 @@
         }
       ],
       "post": {
+        "parameters": [
+          {
+            "name": "skipConstrainedLinks",
+            "description": "When true, do not duplicate links with `n:x` cardinality where `n < ∞`.",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "annotateSkipped",
+            "description": "When true, annotate all columns which were not duplicated as \"Please double check\".",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "Columns to duplicate",
+            "description": "When given, duplicate only those columns. Query parameter `skipConstrainedLinks` dominates given columns.",
+            "required": false,
+            "type": "object",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "columns": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": { "id": { "type": "number" } }
+                  }
+                }
+              }
+            }
+          }
+        ],
         "summary": "Duplicate a row.",
         "description": "Duplicates a row with the same values and returns the duplicated row.",
-        "tags": [
-          "data"
-        ],
+        "tags": ["data"],
         "operationId": "duplicate-row",
         "responses": {
           "200": {
@@ -1408,9 +1320,7 @@
       "get": {
         "summary": "Retrieve all dependent rows.",
         "description": "Retrieve all rows of tables that link to this row.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "retrieve-dependent-rows",
         "responses": {
           "200": {
@@ -1434,9 +1344,7 @@
       "patch": {
         "summary": "Add annotations to this row.",
         "description": "Adds new annotations to this row.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "update-row-annotations",
         "parameters": [
           {
@@ -1471,10 +1379,7 @@
       "delete": {
         "summary": "Remove single attachment from cell.",
         "description": "Removes a specified attachment from a cell.",
-        "tags": [
-          "content",
-          "media"
-        ],
+        "tags": ["content", "media"],
         "operationId": "delete-attachment",
         "responses": {
           "200": {
@@ -1504,9 +1409,7 @@
       "delete": {
         "summary": "Delete a link in a cell",
         "description": "Removes a link from a cell.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "delete-link",
         "responses": {
           "200": {
@@ -1536,9 +1439,7 @@
       "put": {
         "summary": "Changes the order of the link.",
         "description": "Changes the order of the links by reordering the specified link to the beginning, end or in front of another relative link.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "update-cell-link-order",
         "parameters": [
           {
@@ -1567,9 +1468,7 @@
       "get": {
         "summary": "Get a list of foreign rows that can be linked to this cell.",
         "description": "Get a list of foreign rows that can be linked to this cell.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "get-foreign-rows",
         "responses": {
           "200": {
@@ -1596,9 +1495,7 @@
       "post": {
         "summary": "Add an new annotation to a cell.",
         "description": "Adds an annotation to a cell. Annotations with the same type and value will be merged.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "add-cell-annotation",
         "parameters": [
           {
@@ -1606,9 +1503,7 @@
             "in": "body",
             "schema": {
               "type": "object",
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "properties": {
                 "langtags": {
                   "type": "array",
@@ -1618,12 +1513,7 @@
                 },
                 "type": {
                   "type": "string",
-                  "enum": [
-                    "error",
-                    "warning",
-                    "info",
-                    "flag"
-                  ]
+                  "enum": ["error", "warning", "info", "flag"]
                 },
                 "value": {
                   "type": "string",
@@ -1645,9 +1535,7 @@
       "get": {
         "summary": "Get annotations of this cell.",
         "description": "Get annotations of this cell",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "get-cell-annotation",
         "responses": {
           "200": {
@@ -1677,9 +1565,7 @@
       "delete": {
         "summary": "Remove an annotation from a cell.",
         "description": "Removes an annotation for all language tags from a cell.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "clear-cell-annotation",
         "responses": {
           "200": {
@@ -1712,9 +1598,7 @@
       "delete": {
         "summary": "Remove annotation for a language from a cell.",
         "description": "Removes an annotation for a specific language tag from a cell.",
-        "tags": [
-          "content"
-        ],
+        "tags": ["content"],
         "operationId": "clear-cell-annotation-language-tag",
         "responses": {
           "200": {
@@ -1739,9 +1623,7 @@
           }
         }
       },
-      "required": [
-        "description"
-      ]
+      "required": ["description"]
     },
     "Property:DisplayName": {
       "type": "object",
@@ -1754,9 +1636,7 @@
           }
         }
       },
-      "required": [
-        "displayName"
-      ]
+      "required": ["displayName"]
     },
     "Property:TableGroup": {
       "type": "object",
@@ -1773,9 +1653,7 @@
           ]
         }
       },
-      "required": [
-        "displayName"
-      ]
+      "required": ["displayName"]
     },
     "Property:TableGroupWithId": {
       "type": "object",
@@ -1796,9 +1674,7 @@
           "example": "ok"
         }
       },
-      "required": [
-        "status"
-      ]
+      "required": ["status"]
     },
     "Property:Id": {
       "type": "object",
@@ -1808,9 +1684,7 @@
           "example": 423
         }
       },
-      "required": [
-        "id"
-      ]
+      "required": ["id"]
     },
     "CellValue": {
       "type": "any",
@@ -1822,12 +1696,7 @@
     },
     "CellAnnotation": {
       "type": "object",
-      "required": [
-        "uuid",
-        "type",
-        "value",
-        "createdAt"
-      ],
+      "required": ["uuid", "type", "value", "createdAt"],
       "properties": {
         "uuid": {
           "description": "uuid of the annotation",
@@ -1853,9 +1722,7 @@
     },
     "Pagination": {
       "type": "object",
-      "required": [
-        "page"
-      ],
+      "required": ["page"],
       "properties": {
         "page": {
           "description": "Pagination",
@@ -1889,11 +1756,7 @@
         "location": {
           "description": "Sets the new order to be either the first (=start), the last (=end) or in front of another entity (=before).",
           "type": "string",
-          "enum": [
-            "start",
-            "end",
-            "before"
-          ]
+          "enum": ["start", "end", "before"]
         },
         "id": {
           "description": "If using \"before\", we need to provide the id of a relative entity, so the referenced entity can be put before this.",
@@ -1901,9 +1764,7 @@
           "format": "int64"
         }
       },
-      "required": [
-        "location"
-      ]
+      "required": ["location"]
     },
     "Table": {
       "type": "object",
@@ -1918,10 +1779,7 @@
           "$ref": "#/definitions/Property:TableGroupWithId"
         }
       ],
-      "required": [
-        "name",
-        "hidden"
-      ],
+      "required": ["name", "hidden"],
       "properties": {
         "name": {
           "type": "string",
@@ -1954,13 +1812,7 @@
           "$ref": "#/definitions/Property:DisplayName"
         }
       ],
-      "required": [
-        "name",
-        "multilanguage",
-        "ordering",
-        "identifier",
-        "kind"
-      ],
+      "required": ["name", "multilanguage", "ordering", "identifier", "kind"],
       "properties": {
         "name": {
           "description": "An internal name that can be used in the Aggregator, for example.",
@@ -2000,10 +1852,7 @@
         "languageType": {
           "description": "The language type of the column. It can be single language (see \"multilanguage\" property), multilanguage (language) or multicountry (country).",
           "type": "string",
-          "enum": [
-            "country",
-            "language"
-          ]
+          "enum": ["country", "language"]
         },
         "toTable": {
           "description": "The table it links to, if the column is of kind \"link\".",
@@ -2044,10 +1893,7 @@
           }
         }
       },
-      "required": [
-        "id",
-        "value"
-      ]
+      "required": ["id", "value"]
     },
     "Response:Status": {
       "type": "object",
@@ -2083,9 +1929,7 @@
           }
         }
       },
-      "required": [
-        "tables"
-      ]
+      "required": ["tables"]
     },
     "Response: Services": {
       "type": "object",
@@ -2102,9 +1946,7 @@
           }
         }
       },
-      "required": [
-        "services"
-      ]
+      "required": ["services"]
     },
     "Response:Cell": {
       "description": "The cell value.",
@@ -2123,9 +1965,7 @@
           }
         }
       },
-      "required": [
-        "value"
-      ]
+      "required": ["value"]
     },
     "Response:HistoryRows": {
       "description": "All history entries that belongs to the request (filtered based on cell, row or table).",
@@ -2144,9 +1984,7 @@
           }
         }
       },
-      "required": [
-        "rows"
-      ]
+      "required": ["rows"]
     },
     "HistoryRow": {
       "description": "Cell history.",
@@ -2156,13 +1994,7 @@
           "$ref": "#/definitions/Property:Status"
         }
       ],
-      "required": [
-        "revision",
-        "event",
-        "historyType",
-        "author",
-        "timestamp"
-      ],
+      "required": ["revision", "event", "historyType", "author", "timestamp"],
       "properties": {
         "author": {
           "description": "Name of the user who has triggered a change",
@@ -2188,22 +2020,12 @@
         "historyType": {
           "description": "The type of the history entry",
           "type": "string",
-          "enum": [
-            "row",
-            "cell",
-            "comment",
-            "cell_flag",
-            "row_flag"
-          ]
+          "enum": ["row", "cell", "comment", "cell_flag", "row_flag"]
         },
         "languageType": {
           "description": "Name of the user who has triggered a change",
           "type": "string",
-          "enum": [
-            "neutral",
-            "language",
-            "country"
-          ]
+          "enum": ["neutral", "language", "country"]
         },
         "revision": {
           "description": "Identifier sequence of a history entry",
@@ -2274,9 +2096,7 @@
           }
         }
       },
-      "required": [
-        "annotations"
-      ]
+      "required": ["annotations"]
     },
     "Response:Row": {
       "description": "The complete row containing the values of the cells.",
@@ -2302,10 +2122,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "values",
-        "final"
-      ]
+      "required": ["values", "final"]
     },
     "Response:DependentRow": {
       "description": "A row that links to a specified row.",
@@ -2336,10 +2153,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "values",
-        "final"
-      ]
+      "required": ["values", "final"]
     },
     "Response:DependentRows": {
       "description": "All rows that link to the specified row.",
@@ -2358,9 +2172,7 @@
           }
         }
       },
-      "required": [
-        "dependentRows"
-      ]
+      "required": ["dependentRows"]
     },
     "Response:ForeignRows": {
       "description": "An array with all linkable rows to the specified cell",
@@ -2382,15 +2194,11 @@
           }
         }
       },
-      "required": [
-        "rows"
-      ]
+      "required": ["rows"]
     },
     "Request:Folder": {
       "type": "object",
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "name": {
           "type": "string",
@@ -2508,10 +2316,7 @@
     },
     "Response: Cell": {
       "type": "object",
-      "required": [
-        "rows",
-        "status"
-      ],
+      "required": ["rows", "status"],
       "properties": {
         "rows": {
           "type": "array",
@@ -2523,9 +2328,7 @@
                 "example": "Baden-Württemberg"
               }
             },
-            "required": [
-              "value"
-            ]
+            "required": ["value"]
           }
         },
         "status": {
@@ -2537,9 +2340,7 @@
     },
     "Request: Create complete table": {
       "type": "object",
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "columns": {
           "type": "array",
@@ -2577,25 +2378,17 @@
         ],
         "rows": [
           {
-            "values": [
-              "Baden-Württemberg",
-              "Stuttgart"
-            ]
+            "values": ["Baden-Württemberg", "Stuttgart"]
           },
           {
-            "values": [
-              "Bayern",
-              "München"
-            ]
+            "values": ["Bayern", "München"]
           }
         ]
       }
     },
     "Request: Create empty table": {
       "type": "object",
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "name": {
           "type": "string",
@@ -2627,9 +2420,7 @@
     },
     "Request: create update table group": {
       "type": "object",
-      "required": [
-        "displayName"
-      ],
+      "required": ["displayName"],
       "properties": {
         "displayName": {
           "$ref": "#/definitions/Multi-language object"
@@ -2659,16 +2450,11 @@
           "$ref": "#/definitions/Property:TableGroupWithId"
         }
       ],
-      "required": [
-        "tables"
-      ]
+      "required": ["tables"]
     },
     "Request: Create service": {
       "type": "object",
-      "required": [
-        "name",
-        "action"
-      ],
+      "required": ["name", "action"],
       "properties": {
         "name": {
           "type": "string",
@@ -2727,13 +2513,7 @@
     },
     "Response: Complete table": {
       "type": "object",
-      "required": [
-        "columns",
-        "id",
-        "name",
-        "rows",
-        "status"
-      ],
+      "required": ["columns", "id", "name", "rows", "status"],
       "properties": {
         "columns": {
           "type": "array",
@@ -2831,28 +2611,16 @@
     "Response: Versions": {
       "type": "object",
       "description": "The currently used versions",
-      "required": [
-        "versions",
-        "status"
-      ],
+      "required": ["versions", "status"],
       "properties": {
         "versions": {
           "type": "object",
-          "required": [
-            "implementation",
-            "git",
-            "build",
-            "database"
-          ],
+          "required": ["implementation", "git", "build", "database"],
           "properties": {
             "implementation": {
               "type": "object",
               "description": "The underlying backend (usually the JVM)",
-              "required": [
-                "vendor",
-                "title",
-                "version"
-              ],
+              "required": ["vendor", "title", "version"],
               "properties": {
                 "vendor": {
                   "type": "string",
@@ -2874,11 +2642,7 @@
             "git": {
               "type": "object",
               "description": "The underlying git versions",
-              "required": [
-                "branch",
-                "commit",
-                "date"
-              ],
+              "required": ["branch", "commit", "date"],
               "properties": {
                 "branch": {
                   "type": "string",
@@ -2899,10 +2663,7 @@
             },
             "build": {
               "type": "object",
-              "required": [
-                "date",
-                "jdk"
-              ],
+              "required": ["date", "jdk"],
               "properties": {
                 "date": {
                   "type": "string",
@@ -2918,10 +2679,7 @@
             },
             "database": {
               "type": "object",
-              "required": [
-                "current",
-                "specification"
-              ],
+              "required": ["current", "specification"],
               "properties": {
                 "current": {
                   "type": "integer",
@@ -2970,10 +2728,7 @@
     },
     "Response: Array of tables": {
       "type": "object",
-      "required": [
-        "status",
-        "tables"
-      ],
+      "required": ["status", "tables"],
       "properties": {
         "tables": {
           "type": "array",
@@ -3003,11 +2758,7 @@
     },
     "Shared Response: Table": {
       "type": "object",
-      "required": [
-        "id",
-        "name",
-        "status"
-      ],
+      "required": ["id", "name", "status"],
       "properties": {
         "name": {
           "type": "string",
@@ -3034,12 +2785,7 @@
     },
     "Shared Response: Column": {
       "type": "object",
-      "required": [
-        "id",
-        "kind",
-        "name",
-        "ordering"
-      ],
+      "required": ["id", "kind", "name", "ordering"],
       "properties": {
         "kind": {
           "$ref": "#/definitions/Enum: Column type"
@@ -3075,10 +2821,7 @@
     },
     "Shared Response: Row": {
       "type": "object",
-      "required": [
-        "id",
-        "values"
-      ],
+      "required": ["id", "values"],
       "properties": {
         "values": {
           "type": "array",
@@ -3097,19 +2840,12 @@
       "description": "A row contains all column values of this specific table.",
       "example": {
         "id": 1,
-        "values": [
-          "Baden-Württemberg",
-          35751
-        ]
+        "values": ["Baden-Württemberg", 35751]
       }
     },
     "Shared Response: Service": {
       "type": "object",
-      "required": [
-        "id",
-        "name",
-        "status"
-      ],
+      "required": ["id", "name", "status"],
       "properties": {
         "status": {
           "type": "string",
@@ -3190,9 +2926,7 @@
     },
     "Shared Request: Row": {
       "type": "object",
-      "required": [
-        "values"
-      ],
+      "required": ["values"],
       "properties": {
         "values": {
           "type": "array",
@@ -3204,18 +2938,12 @@
       },
       "description": "A row object, which is used to add a new row to a table, has only an array of values.",
       "example": {
-        "values": [
-          "Column 1 Value",
-          "Column 2 Value"
-        ]
+        "values": ["Column 1 Value", "Column 2 Value"]
       }
     },
     "Response: Columns": {
       "type": "object",
-      "required": [
-        "columns",
-        "status"
-      ],
+      "required": ["columns", "status"],
       "properties": {
         "columns": {
           "type": "array",
@@ -3274,9 +3002,7 @@
               "example": "d6a011e9-3599-400c-9651-9a778dfc3f9c.jpg"
             }
           },
-          "required": [
-            "de-DE"
-          ]
+          "required": ["de-DE"]
         },
         "createdAt": {
           "type": "string",
@@ -3290,9 +3016,7 @@
               "example": "01520_chicagoskyline_1920x1200.jpg"
             }
           },
-          "required": [
-            "de-DE"
-          ]
+          "required": ["de-DE"]
         },
         "description": {
           "type": "object",
@@ -3302,9 +3026,7 @@
               "example": "Deutsche Beschreibung"
             }
           },
-          "required": [
-            "de-DE"
-          ]
+          "required": ["de-DE"]
         },
         "mimeType": {
           "type": "object",
@@ -3314,9 +3036,7 @@
               "example": "image/jpeg"
             }
           },
-          "required": [
-            "de-DE"
-          ]
+          "required": ["de-DE"]
         },
         "title": {
           "type": "object",
@@ -3326,9 +3046,7 @@
               "example": "Deutscher Titel"
             }
           },
-          "required": [
-            "de-DE"
-          ]
+          "required": ["de-DE"]
         },
         "uuid": {
           "type": "string",
@@ -3342,9 +3060,7 @@
               "example": "/files/7e3982f3-7328-45f9-b499-9424a20bf5ff/de-DE/01520_chicagoskyline_1920x1200.jpg"
             }
           },
-          "required": [
-            "de-DE"
-          ]
+          "required": ["de-DE"]
         },
         "updatedAt": {
           "type": "string",
@@ -3366,10 +3082,7 @@
     },
     "Response: Rows": {
       "type": "object",
-      "required": [
-        "rows",
-        "status"
-      ],
+      "required": ["rows", "status"],
       "properties": {
         "rows": {
           "type": "array",
@@ -3442,11 +3155,7 @@
     "Enum: Service type": {
       "type": "string",
       "description": "Different types of services",
-      "enum": [
-        "action",
-        "filter",
-        "listener"
-      ]
+      "enum": ["action", "filter", "listener"]
     },
     "Response: Subfolder": {
       "type": "object",
@@ -3488,11 +3197,7 @@
     },
     "Shared Request: Column": {
       "type": "array",
-      "required": [
-        "kind",
-        "name",
-        "ordering"
-      ],
+      "required": ["kind", "name", "ordering"],
       "properties": {
         "kind": {
           "$ref": "#/definitions/Enum: Column type"
@@ -3526,11 +3231,7 @@
         "groups": {
           "type": "array",
           "description": "A list of column ids that should build a group column",
-          "example": [
-            1,
-            2,
-            3
-          ]
+          "example": [1, 2, 3]
         },
         "formatPattern": {
           "type": "string",
@@ -3569,10 +3270,7 @@
             "en": "a group example, the column ids in groups array must be absolute"
           },
           "ordering": "3",
-          "groups": [
-            1,
-            2
-          ],
+          "groups": [1, 2],
           "formatPattern": "city {{1}} has {{2}} inhabitants"
         }
       ]

--- a/src/main/resources/swagger.json
+++ b/src/main/resources/swagger.json
@@ -10,11 +10,17 @@
     },
     "version": "1.0.0"
   },
-  "schemes": ["$SCHEME$"],
+  "schemes": [
+    "$SCHEME$"
+  ],
   "host": "$HOST$",
   "basePath": "$BASEPATH$",
-  "consumes": ["application/json"],
-  "produces": ["application/json"],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
   "externalDocs": {
     "description": "GitHub project",
     "url": "https://github.com/campudus/tableaux"
@@ -38,7 +44,9 @@
       "post": {
         "summary": "Create file handle",
         "description": "Creates a new temporary file handle.",
-        "tags": ["media"],
+        "tags": [
+          "media"
+        ],
         "operationId": "create-file-handle",
         "parameters": [
           {
@@ -48,7 +56,11 @@
             "required": true,
             "schema": {
               "type": "object",
-              "required": ["folder", "description", "title"],
+              "required": [
+                "folder",
+                "description",
+                "title"
+              ],
               "properties": {
                 "folder": {
                   "type": "integer",
@@ -155,7 +167,9 @@
       "get": {
         "summary": "Get file meta-information",
         "description": "Returns meta-information about a file.",
-        "tags": ["media"],
+        "tags": [
+          "media"
+        ],
         "operationId": "get-file-meta-information",
         "responses": {
           "200": {
@@ -169,7 +183,9 @@
       "put": {
         "summary": "Change file meta-information",
         "description": "Changes meta information of file.",
-        "tags": ["media"],
+        "tags": [
+          "media"
+        ],
         "operationId": "change-file-meta-information",
         "parameters": [
           {
@@ -212,7 +228,9 @@
       "delete": {
         "summary": "Delete file",
         "description": "",
-        "tags": ["media"],
+        "tags": [
+          "media"
+        ],
         "operationId": "delete-file",
         "responses": {
           "200": {
@@ -236,7 +254,9 @@
       "put": {
         "summary": "Upload file",
         "description": "Uploads/replaces a language specific file for this file handle.",
-        "tags": ["media"],
+        "tags": [
+          "media"
+        ],
         "operationId": "upload-file",
         "responses": {
           "200": {
@@ -247,7 +267,9 @@
       "delete": {
         "summary": "Delete file (language specific)",
         "description": "",
-        "tags": ["media"],
+        "tags": [
+          "media"
+        ],
         "operationId": "delete-file-language-specific",
         "responses": {
           "200": {
@@ -260,7 +282,9 @@
       "get": {
         "summary": "Get root folder",
         "description": "Returns the root folder. Has no ID because it can't be changed or deleted.",
-        "tags": ["media"],
+        "tags": [
+          "media"
+        ],
         "operationId": "get-root-folder",
         "parameters": [
           {
@@ -289,7 +313,9 @@
       "post": {
         "summary": "Create folder",
         "description": "Creates a new folder.",
-        "tags": ["media"],
+        "tags": [
+          "media"
+        ],
         "operationId": "create-folder",
         "parameters": [
           {
@@ -317,7 +343,9 @@
       "get": {
         "summary": "Get folder",
         "description": "Returns a specific folder. Hierarchy is not relevant.",
-        "tags": ["media"],
+        "tags": [
+          "media"
+        ],
         "operationId": "get-folder",
         "parameters": [
           {
@@ -340,7 +368,9 @@
       "put": {
         "summary": "Change folder",
         "description": "Changes folder.",
-        "tags": ["media"],
+        "tags": [
+          "media"
+        ],
         "operationId": "change-folder",
         "parameters": [
           {
@@ -361,7 +391,9 @@
       "delete": {
         "summary": "Delete folder",
         "description": "",
-        "tags": ["media"],
+        "tags": [
+          "media"
+        ],
         "operationId": "delete-folder",
         "responses": {
           "200": {
@@ -374,7 +406,9 @@
       "post": {
         "summary": "Reset system tables",
         "description": "Resets whole schema and re-initialize system tables",
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "operationId": "reset-system-tables",
         "parameters": [
           {
@@ -392,7 +426,9 @@
       "post": {
         "summary": "Create demo tables",
         "description": "Creates two demo tables (Bundesländer, Regierungsbezirke) with links.",
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "operationId": "create-demo-tables",
         "parameters": [
           {
@@ -410,10 +446,14 @@
       "get": {
         "summary": "Get current version",
         "description": "",
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "operationId": "get-version",
         "consumes": [],
-        "produces": ["application/json"],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -435,10 +475,14 @@
       "get": {
         "summary": "Get all services",
         "description": "Returns an array containing all available services with their metadata.",
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "operationId": "get-all-services",
         "consumes": [],
-        "produces": ["application/json"],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -458,7 +502,9 @@
       "post": {
         "summary": "Create a new service",
         "description": "Creates the service.",
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "operationId": "create-new-service",
         "parameters": [
           {
@@ -495,7 +541,9 @@
       "get": {
         "summary": "Get service",
         "description": "Returns the metadata of a service.",
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "operationId": "get-service",
         "responses": {
           "200": {
@@ -512,7 +560,9 @@
       "patch": {
         "summary": "Change service",
         "description": "Changes the service and returns its current metadata.",
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "operationId": "change-service",
         "parameters": [
           {
@@ -539,7 +589,9 @@
       "delete": {
         "summary": "Delete a service",
         "description": "Drops the complete service and deletes its definition.",
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "operationId": "delete-service",
         "responses": {
           "200": {
@@ -555,7 +607,9 @@
       "post": {
         "summary": "Update system tables",
         "description": "Updates schema of system tables. To get the nonce, take a look at the backend logs.",
-        "tags": ["system"],
+        "tags": [
+          "system"
+        ],
         "operationId": "update-system-tables",
         "parameters": [
           {
@@ -582,7 +636,9 @@
       "post": {
         "summary": "Create a complete table with columns and rows",
         "description": "Adds the table structure.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "create-new-complete-table",
         "parameters": [
           {
@@ -614,10 +670,14 @@
       "get": {
         "summary": "Get all tables",
         "description": "Returns an array containing all available tables with their metadata.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "get-all-tables",
         "consumes": [],
-        "produces": ["application/json"],
+        "produces": [
+          "application/json"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -637,7 +697,9 @@
       "post": {
         "summary": "Create a new empty table",
         "description": "Adds the table structure.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "create-new-empty-table",
         "parameters": [
           {
@@ -674,7 +736,9 @@
       "get": {
         "summary": "Get table",
         "description": "Returns the metadata of a table.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "get-table",
         "parameters": [
           {
@@ -693,7 +757,9 @@
       "post": {
         "summary": "Change table",
         "description": "Changes the table",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "change-table",
         "parameters": [
           {
@@ -714,7 +780,9 @@
       "delete": {
         "summary": "Delete a table",
         "description": "Drops the complete table and deletes its definition.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "delete-table",
         "responses": {
           "200": {
@@ -735,7 +803,9 @@
       "get": {
         "summary": "Get columns definition",
         "description": "Returns all columns of specific table",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "get-columns-definition",
         "responses": {
           "200": {
@@ -749,7 +819,9 @@
       "post": {
         "summary": "Create new column(s)",
         "description": "Alters the user table and add the column definition to the system table.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "create-new-column",
         "parameters": [
           {
@@ -758,7 +830,9 @@
             "required": false,
             "schema": {
               "type": "array",
-              "required": ["columns"],
+              "required": [
+                "columns"
+              ],
               "properties": {
                 "columns": {
                   "$ref": "#/definitions/Shared Request: Column"
@@ -787,14 +861,20 @@
                       "example": 3
                     }
                   },
-                  "required": ["id", "ordering"]
+                  "required": [
+                    "id",
+                    "ordering"
+                  ]
                 },
                 "status": {
                   "type": "string",
                   "example": "ok"
                 }
               },
-              "required": ["columns", "status"]
+              "required": [
+                "columns",
+                "status"
+              ]
             }
           }
         }
@@ -812,7 +892,9 @@
       "get": {
         "summary": "Get column definition",
         "description": "Returns information about a specific column.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "get-column-definition",
         "responses": {
           "200": {
@@ -826,7 +908,9 @@
       "post": {
         "summary": "Change column",
         "description": "Alters the column definition.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "change-column",
         "parameters": [
           {
@@ -861,7 +945,9 @@
       "delete": {
         "summary": "Delete column",
         "description": "Deletes column from user table and table definition.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "delete-column",
         "responses": {
           "200": {
@@ -874,7 +960,9 @@
       "post": {
         "summary": "Create table group",
         "description": "Creates a table group.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "create-table-group",
         "parameters": [
           {
@@ -902,7 +990,9 @@
       "post": {
         "summary": "Change table group",
         "description": "Changes a table group.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "change-table-group",
         "parameters": [
           {
@@ -923,7 +1013,9 @@
       "delete": {
         "summary": "Delete table group",
         "description": "Deletes a table group.",
-        "tags": ["structure"],
+        "tags": [
+          "structure"
+        ],
         "operationId": "delete-table-group",
         "responses": {
           "200": {
@@ -950,7 +1042,9 @@
       "get": {
         "summary": "Get specific cell value",
         "description": "Returns the value of a specified cell.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "retrieve-cell",
         "responses": {
           "200": {
@@ -964,7 +1058,9 @@
       "post": {
         "summary": "DEPRECATED - Update cell or add link/attachment",
         "description": "DEPRECATED: Use same route with PATCH instead. Updates the value of specified cell. This can add links, attachments, multi-language contents and replaces simple values such as numbers, booleans or strings.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "update-cell-deprecated",
         "parameters": [
           {
@@ -983,7 +1079,9 @@
       "patch": {
         "summary": "Update cell or add link/attachment",
         "description": "Updates the value of specified cell. This can add links, attachments, multi-language contents and replaces simple values such as numbers, booleans or strings.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "update-cell",
         "parameters": [
           {
@@ -1002,7 +1100,9 @@
       "put": {
         "summary": "Replace cell value",
         "description": "Replace the current value of the specified cell. This overwrites all languages in a multi-language cell or deletes all links and replaces the data with the provided value.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "replace-cell",
         "parameters": [
           {
@@ -1021,7 +1121,9 @@
       "delete": {
         "summary": "Remove a cell value.",
         "description": "Clears the set cell value and reset it to its default value.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "clear-cell-value",
         "responses": {
           "200": {
@@ -1048,7 +1150,9 @@
       "get": {
         "summary": "Retrieves the history entries of a table",
         "description": "Returns the history entries of a table.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "retrieve-table-history-cell",
         "responses": {
           "200": {
@@ -1078,7 +1182,9 @@
       "get": {
         "summary": "Retrieves the history entries of a row",
         "description": "Returns the history entries of a row.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "retrieve-row-history-cell",
         "responses": {
           "200": {
@@ -1111,7 +1217,9 @@
       "get": {
         "summary": "Retrieves the history entries of a cell",
         "description": "Returns the history entries of a specified cell.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "retrieve-cell-history-cell",
         "responses": {
           "200": {
@@ -1132,7 +1240,9 @@
       "get": {
         "summary": "Get all rows",
         "description": "Returns just the rows of the table",
-        "tags": ["data"],
+        "tags": [
+          "data"
+        ],
         "operationId": "get-all-rows",
         "responses": {
           "200": {
@@ -1152,7 +1262,9 @@
       "post": {
         "summary": "Create new row",
         "description": "Adds new row to user table.",
-        "tags": ["data"],
+        "tags": [
+          "data"
+        ],
         "operationId": "create-new-row",
         "parameters": [
           {
@@ -1161,7 +1273,10 @@
             "required": false,
             "schema": {
               "type": "object",
-              "required": ["columns", "rows"],
+              "required": [
+                "columns",
+                "rows"
+              ],
               "properties": {
                 "columns": {
                   "type": "array",
@@ -1173,7 +1288,9 @@
                       "description": "Column id"
                     }
                   },
-                  "required": ["id"]
+                  "required": [
+                    "id"
+                  ]
                 },
                 "rows": {
                   "type": "array",
@@ -1221,7 +1338,9 @@
       "get": {
         "summary": "Get single row",
         "description": "Returns a single row and its values.",
-        "tags": ["data"],
+        "tags": [
+          "data"
+        ],
         "operationId": "get-single-row",
         "responses": {
           "200": {
@@ -1235,7 +1354,9 @@
       "delete": {
         "summary": "Delete row",
         "description": "Deletes a row from user table. Optionally, all rows associated with this row can be replaced by a another rowId provided via query parameter `replacingRowId`",
-        "tags": ["data"],
+        "tags": [
+          "data"
+        ],
         "operationId": "delete-row",
         "parameters": [
           {
@@ -1287,7 +1408,11 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "properties": { "id": { "type": "number" } }
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      }
+                    }
                   }
                 }
               }
@@ -1296,7 +1421,9 @@
         ],
         "summary": "Duplicate a row.",
         "description": "Duplicates a row with the same values and returns the duplicated row.",
-        "tags": ["data"],
+        "tags": [
+          "data"
+        ],
         "operationId": "duplicate-row",
         "responses": {
           "200": {
@@ -1320,7 +1447,9 @@
       "get": {
         "summary": "Retrieve all dependent rows.",
         "description": "Retrieve all rows of tables that link to this row.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "retrieve-dependent-rows",
         "responses": {
           "200": {
@@ -1344,7 +1473,9 @@
       "patch": {
         "summary": "Add annotations to this row.",
         "description": "Adds new annotations to this row.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "update-row-annotations",
         "parameters": [
           {
@@ -1379,7 +1510,10 @@
       "delete": {
         "summary": "Remove single attachment from cell.",
         "description": "Removes a specified attachment from a cell.",
-        "tags": ["content", "media"],
+        "tags": [
+          "content",
+          "media"
+        ],
         "operationId": "delete-attachment",
         "responses": {
           "200": {
@@ -1409,7 +1543,9 @@
       "delete": {
         "summary": "Delete a link in a cell",
         "description": "Removes a link from a cell.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "delete-link",
         "responses": {
           "200": {
@@ -1439,7 +1575,9 @@
       "put": {
         "summary": "Changes the order of the link.",
         "description": "Changes the order of the links by reordering the specified link to the beginning, end or in front of another relative link.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "update-cell-link-order",
         "parameters": [
           {
@@ -1468,7 +1606,9 @@
       "get": {
         "summary": "Get a list of foreign rows that can be linked to this cell.",
         "description": "Get a list of foreign rows that can be linked to this cell.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "get-foreign-rows",
         "responses": {
           "200": {
@@ -1495,7 +1635,9 @@
       "post": {
         "summary": "Add an new annotation to a cell.",
         "description": "Adds an annotation to a cell. Annotations with the same type and value will be merged.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "add-cell-annotation",
         "parameters": [
           {
@@ -1503,7 +1645,9 @@
             "in": "body",
             "schema": {
               "type": "object",
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "properties": {
                 "langtags": {
                   "type": "array",
@@ -1513,7 +1657,12 @@
                 },
                 "type": {
                   "type": "string",
-                  "enum": ["error", "warning", "info", "flag"]
+                  "enum": [
+                    "error",
+                    "warning",
+                    "info",
+                    "flag"
+                  ]
                 },
                 "value": {
                   "type": "string",
@@ -1535,7 +1684,9 @@
       "get": {
         "summary": "Get annotations of this cell.",
         "description": "Get annotations of this cell",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "get-cell-annotation",
         "responses": {
           "200": {
@@ -1565,7 +1716,9 @@
       "delete": {
         "summary": "Remove an annotation from a cell.",
         "description": "Removes an annotation for all language tags from a cell.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "clear-cell-annotation",
         "responses": {
           "200": {
@@ -1598,7 +1751,9 @@
       "delete": {
         "summary": "Remove annotation for a language from a cell.",
         "description": "Removes an annotation for a specific language tag from a cell.",
-        "tags": ["content"],
+        "tags": [
+          "content"
+        ],
         "operationId": "clear-cell-annotation-language-tag",
         "responses": {
           "200": {
@@ -1623,7 +1778,9 @@
           }
         }
       },
-      "required": ["description"]
+      "required": [
+        "description"
+      ]
     },
     "Property:DisplayName": {
       "type": "object",
@@ -1636,7 +1793,9 @@
           }
         }
       },
-      "required": ["displayName"]
+      "required": [
+        "displayName"
+      ]
     },
     "Property:TableGroup": {
       "type": "object",
@@ -1653,7 +1812,9 @@
           ]
         }
       },
-      "required": ["displayName"]
+      "required": [
+        "displayName"
+      ]
     },
     "Property:TableGroupWithId": {
       "type": "object",
@@ -1674,7 +1835,9 @@
           "example": "ok"
         }
       },
-      "required": ["status"]
+      "required": [
+        "status"
+      ]
     },
     "Property:Id": {
       "type": "object",
@@ -1684,7 +1847,9 @@
           "example": 423
         }
       },
-      "required": ["id"]
+      "required": [
+        "id"
+      ]
     },
     "CellValue": {
       "type": "any",
@@ -1696,7 +1861,12 @@
     },
     "CellAnnotation": {
       "type": "object",
-      "required": ["uuid", "type", "value", "createdAt"],
+      "required": [
+        "uuid",
+        "type",
+        "value",
+        "createdAt"
+      ],
       "properties": {
         "uuid": {
           "description": "uuid of the annotation",
@@ -1722,7 +1892,9 @@
     },
     "Pagination": {
       "type": "object",
-      "required": ["page"],
+      "required": [
+        "page"
+      ],
       "properties": {
         "page": {
           "description": "Pagination",
@@ -1756,7 +1928,11 @@
         "location": {
           "description": "Sets the new order to be either the first (=start), the last (=end) or in front of another entity (=before).",
           "type": "string",
-          "enum": ["start", "end", "before"]
+          "enum": [
+            "start",
+            "end",
+            "before"
+          ]
         },
         "id": {
           "description": "If using \"before\", we need to provide the id of a relative entity, so the referenced entity can be put before this.",
@@ -1764,7 +1940,9 @@
           "format": "int64"
         }
       },
-      "required": ["location"]
+      "required": [
+        "location"
+      ]
     },
     "Table": {
       "type": "object",
@@ -1779,7 +1957,10 @@
           "$ref": "#/definitions/Property:TableGroupWithId"
         }
       ],
-      "required": ["name", "hidden"],
+      "required": [
+        "name",
+        "hidden"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -1812,7 +1993,13 @@
           "$ref": "#/definitions/Property:DisplayName"
         }
       ],
-      "required": ["name", "multilanguage", "ordering", "identifier", "kind"],
+      "required": [
+        "name",
+        "multilanguage",
+        "ordering",
+        "identifier",
+        "kind"
+      ],
       "properties": {
         "name": {
           "description": "An internal name that can be used in the Aggregator, for example.",
@@ -1852,7 +2039,10 @@
         "languageType": {
           "description": "The language type of the column. It can be single language (see \"multilanguage\" property), multilanguage (language) or multicountry (country).",
           "type": "string",
-          "enum": ["country", "language"]
+          "enum": [
+            "country",
+            "language"
+          ]
         },
         "toTable": {
           "description": "The table it links to, if the column is of kind \"link\".",
@@ -1893,7 +2083,10 @@
           }
         }
       },
-      "required": ["id", "value"]
+      "required": [
+        "id",
+        "value"
+      ]
     },
     "Response:Status": {
       "type": "object",
@@ -1929,7 +2122,9 @@
           }
         }
       },
-      "required": ["tables"]
+      "required": [
+        "tables"
+      ]
     },
     "Response: Services": {
       "type": "object",
@@ -1946,7 +2141,9 @@
           }
         }
       },
-      "required": ["services"]
+      "required": [
+        "services"
+      ]
     },
     "Response:Cell": {
       "description": "The cell value.",
@@ -1965,7 +2162,9 @@
           }
         }
       },
-      "required": ["value"]
+      "required": [
+        "value"
+      ]
     },
     "Response:HistoryRows": {
       "description": "All history entries that belongs to the request (filtered based on cell, row or table).",
@@ -1984,7 +2183,9 @@
           }
         }
       },
-      "required": ["rows"]
+      "required": [
+        "rows"
+      ]
     },
     "HistoryRow": {
       "description": "Cell history.",
@@ -1994,7 +2195,13 @@
           "$ref": "#/definitions/Property:Status"
         }
       ],
-      "required": ["revision", "event", "historyType", "author", "timestamp"],
+      "required": [
+        "revision",
+        "event",
+        "historyType",
+        "author",
+        "timestamp"
+      ],
       "properties": {
         "author": {
           "description": "Name of the user who has triggered a change",
@@ -2020,12 +2227,22 @@
         "historyType": {
           "description": "The type of the history entry",
           "type": "string",
-          "enum": ["row", "cell", "comment", "cell_flag", "row_flag"]
+          "enum": [
+            "row",
+            "cell",
+            "comment",
+            "cell_flag",
+            "row_flag"
+          ]
         },
         "languageType": {
           "description": "Name of the user who has triggered a change",
           "type": "string",
-          "enum": ["neutral", "language", "country"]
+          "enum": [
+            "neutral",
+            "language",
+            "country"
+          ]
         },
         "revision": {
           "description": "Identifier sequence of a history entry",
@@ -2096,7 +2313,9 @@
           }
         }
       },
-      "required": ["annotations"]
+      "required": [
+        "annotations"
+      ]
     },
     "Response:Row": {
       "description": "The complete row containing the values of the cells.",
@@ -2122,7 +2341,10 @@
           "type": "boolean"
         }
       },
-      "required": ["values", "final"]
+      "required": [
+        "values",
+        "final"
+      ]
     },
     "Response:DependentRow": {
       "description": "A row that links to a specified row.",
@@ -2153,7 +2375,10 @@
           "type": "boolean"
         }
       },
-      "required": ["values", "final"]
+      "required": [
+        "values",
+        "final"
+      ]
     },
     "Response:DependentRows": {
       "description": "All rows that link to the specified row.",
@@ -2172,7 +2397,9 @@
           }
         }
       },
-      "required": ["dependentRows"]
+      "required": [
+        "dependentRows"
+      ]
     },
     "Response:ForeignRows": {
       "description": "An array with all linkable rows to the specified cell",
@@ -2194,11 +2421,15 @@
           }
         }
       },
-      "required": ["rows"]
+      "required": [
+        "rows"
+      ]
     },
     "Request:Folder": {
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -2316,7 +2547,10 @@
     },
     "Response: Cell": {
       "type": "object",
-      "required": ["rows", "status"],
+      "required": [
+        "rows",
+        "status"
+      ],
       "properties": {
         "rows": {
           "type": "array",
@@ -2328,7 +2562,9 @@
                 "example": "Baden-Württemberg"
               }
             },
-            "required": ["value"]
+            "required": [
+              "value"
+            ]
           }
         },
         "status": {
@@ -2340,7 +2576,9 @@
     },
     "Request: Create complete table": {
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "columns": {
           "type": "array",
@@ -2378,17 +2616,25 @@
         ],
         "rows": [
           {
-            "values": ["Baden-Württemberg", "Stuttgart"]
+            "values": [
+              "Baden-Württemberg",
+              "Stuttgart"
+            ]
           },
           {
-            "values": ["Bayern", "München"]
+            "values": [
+              "Bayern",
+              "München"
+            ]
           }
         ]
       }
     },
     "Request: Create empty table": {
       "type": "object",
-      "required": ["name"],
+      "required": [
+        "name"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -2420,7 +2666,9 @@
     },
     "Request: create update table group": {
       "type": "object",
-      "required": ["displayName"],
+      "required": [
+        "displayName"
+      ],
       "properties": {
         "displayName": {
           "$ref": "#/definitions/Multi-language object"
@@ -2450,11 +2698,16 @@
           "$ref": "#/definitions/Property:TableGroupWithId"
         }
       ],
-      "required": ["tables"]
+      "required": [
+        "tables"
+      ]
     },
     "Request: Create service": {
       "type": "object",
-      "required": ["name", "action"],
+      "required": [
+        "name",
+        "action"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -2513,7 +2766,13 @@
     },
     "Response: Complete table": {
       "type": "object",
-      "required": ["columns", "id", "name", "rows", "status"],
+      "required": [
+        "columns",
+        "id",
+        "name",
+        "rows",
+        "status"
+      ],
       "properties": {
         "columns": {
           "type": "array",
@@ -2611,16 +2870,28 @@
     "Response: Versions": {
       "type": "object",
       "description": "The currently used versions",
-      "required": ["versions", "status"],
+      "required": [
+        "versions",
+        "status"
+      ],
       "properties": {
         "versions": {
           "type": "object",
-          "required": ["implementation", "git", "build", "database"],
+          "required": [
+            "implementation",
+            "git",
+            "build",
+            "database"
+          ],
           "properties": {
             "implementation": {
               "type": "object",
               "description": "The underlying backend (usually the JVM)",
-              "required": ["vendor", "title", "version"],
+              "required": [
+                "vendor",
+                "title",
+                "version"
+              ],
               "properties": {
                 "vendor": {
                   "type": "string",
@@ -2642,7 +2913,11 @@
             "git": {
               "type": "object",
               "description": "The underlying git versions",
-              "required": ["branch", "commit", "date"],
+              "required": [
+                "branch",
+                "commit",
+                "date"
+              ],
               "properties": {
                 "branch": {
                   "type": "string",
@@ -2663,7 +2938,10 @@
             },
             "build": {
               "type": "object",
-              "required": ["date", "jdk"],
+              "required": [
+                "date",
+                "jdk"
+              ],
               "properties": {
                 "date": {
                   "type": "string",
@@ -2679,7 +2957,10 @@
             },
             "database": {
               "type": "object",
-              "required": ["current", "specification"],
+              "required": [
+                "current",
+                "specification"
+              ],
               "properties": {
                 "current": {
                   "type": "integer",
@@ -2728,7 +3009,10 @@
     },
     "Response: Array of tables": {
       "type": "object",
-      "required": ["status", "tables"],
+      "required": [
+        "status",
+        "tables"
+      ],
       "properties": {
         "tables": {
           "type": "array",
@@ -2758,7 +3042,11 @@
     },
     "Shared Response: Table": {
       "type": "object",
-      "required": ["id", "name", "status"],
+      "required": [
+        "id",
+        "name",
+        "status"
+      ],
       "properties": {
         "name": {
           "type": "string",
@@ -2785,7 +3073,12 @@
     },
     "Shared Response: Column": {
       "type": "object",
-      "required": ["id", "kind", "name", "ordering"],
+      "required": [
+        "id",
+        "kind",
+        "name",
+        "ordering"
+      ],
       "properties": {
         "kind": {
           "$ref": "#/definitions/Enum: Column type"
@@ -2821,7 +3114,10 @@
     },
     "Shared Response: Row": {
       "type": "object",
-      "required": ["id", "values"],
+      "required": [
+        "id",
+        "values"
+      ],
       "properties": {
         "values": {
           "type": "array",
@@ -2840,12 +3136,19 @@
       "description": "A row contains all column values of this specific table.",
       "example": {
         "id": 1,
-        "values": ["Baden-Württemberg", 35751]
+        "values": [
+          "Baden-Württemberg",
+          35751
+        ]
       }
     },
     "Shared Response: Service": {
       "type": "object",
-      "required": ["id", "name", "status"],
+      "required": [
+        "id",
+        "name",
+        "status"
+      ],
       "properties": {
         "status": {
           "type": "string",
@@ -2926,7 +3229,9 @@
     },
     "Shared Request: Row": {
       "type": "object",
-      "required": ["values"],
+      "required": [
+        "values"
+      ],
       "properties": {
         "values": {
           "type": "array",
@@ -2938,12 +3243,18 @@
       },
       "description": "A row object, which is used to add a new row to a table, has only an array of values.",
       "example": {
-        "values": ["Column 1 Value", "Column 2 Value"]
+        "values": [
+          "Column 1 Value",
+          "Column 2 Value"
+        ]
       }
     },
     "Response: Columns": {
       "type": "object",
-      "required": ["columns", "status"],
+      "required": [
+        "columns",
+        "status"
+      ],
       "properties": {
         "columns": {
           "type": "array",
@@ -3002,7 +3313,9 @@
               "example": "d6a011e9-3599-400c-9651-9a778dfc3f9c.jpg"
             }
           },
-          "required": ["de-DE"]
+          "required": [
+            "de-DE"
+          ]
         },
         "createdAt": {
           "type": "string",
@@ -3016,7 +3329,9 @@
               "example": "01520_chicagoskyline_1920x1200.jpg"
             }
           },
-          "required": ["de-DE"]
+          "required": [
+            "de-DE"
+          ]
         },
         "description": {
           "type": "object",
@@ -3026,7 +3341,9 @@
               "example": "Deutsche Beschreibung"
             }
           },
-          "required": ["de-DE"]
+          "required": [
+            "de-DE"
+          ]
         },
         "mimeType": {
           "type": "object",
@@ -3036,7 +3353,9 @@
               "example": "image/jpeg"
             }
           },
-          "required": ["de-DE"]
+          "required": [
+            "de-DE"
+          ]
         },
         "title": {
           "type": "object",
@@ -3046,7 +3365,9 @@
               "example": "Deutscher Titel"
             }
           },
-          "required": ["de-DE"]
+          "required": [
+            "de-DE"
+          ]
         },
         "uuid": {
           "type": "string",
@@ -3060,7 +3381,9 @@
               "example": "/files/7e3982f3-7328-45f9-b499-9424a20bf5ff/de-DE/01520_chicagoskyline_1920x1200.jpg"
             }
           },
-          "required": ["de-DE"]
+          "required": [
+            "de-DE"
+          ]
         },
         "updatedAt": {
           "type": "string",
@@ -3082,7 +3405,10 @@
     },
     "Response: Rows": {
       "type": "object",
-      "required": ["rows", "status"],
+      "required": [
+        "rows",
+        "status"
+      ],
       "properties": {
         "rows": {
           "type": "array",
@@ -3155,7 +3481,11 @@
     "Enum: Service type": {
       "type": "string",
       "description": "Different types of services",
-      "enum": ["action", "filter", "listener"]
+      "enum": [
+        "action",
+        "filter",
+        "listener"
+      ]
     },
     "Response: Subfolder": {
       "type": "object",
@@ -3197,7 +3527,11 @@
     },
     "Shared Request: Column": {
       "type": "array",
-      "required": ["kind", "name", "ordering"],
+      "required": [
+        "kind",
+        "name",
+        "ordering"
+      ],
       "properties": {
         "kind": {
           "$ref": "#/definitions/Enum: Column type"
@@ -3231,7 +3565,11 @@
         "groups": {
           "type": "array",
           "description": "A list of column ids that should build a group column",
-          "example": [1, 2, 3]
+          "example": [
+            1,
+            2,
+            3
+          ]
         },
         "formatPattern": {
           "type": "string",
@@ -3270,7 +3608,10 @@
             "en": "a group example, the column ids in groups array must be absolute"
           },
           "ordering": "3",
-          "groups": [1, 2],
+          "groups": [
+            1,
+            2
+          ],
           "formatPattern": "city {{1}} has {{2}} inhabitants"
         }
       ]

--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -17,6 +17,7 @@ import scala.concurrent.Future
 import scala.util.Try
 
 import java.util.UUID
+import com.campudus.tableaux.database.model.DuplicateLinkOption
 
 object TableauxController {
 
@@ -286,12 +287,12 @@ class TableauxController(
     } yield EmptyObject()
   }
 
-  def duplicateRow(tableId: TableId, rowId: RowId)(implicit user: TableauxUser): Future[Row] = {
+  def duplicateRow(tableId: TableId, rowId: RowId, linkOptions: Option[DuplicateLinkOption])(implicit user: TableauxUser): Future[Row] = {
     checkArguments(greaterZero(tableId), greaterZero(rowId))
     logger.info(s"duplicateRow $tableId $rowId")
     for {
       table <- repository.retrieveTable(tableId)
-      duplicated <- repository.duplicateRow(table, rowId)
+      duplicated <- repository.duplicateRow(table, rowId, linkOptions)
     } yield duplicated
   }
 

--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -17,7 +17,7 @@ import scala.concurrent.Future
 import scala.util.Try
 
 import java.util.UUID
-import com.campudus.tableaux.database.model.DuplicateLinkOption
+import com.campudus.tableaux.database.model.DuplicateRowOptions
 
 object TableauxController {
 
@@ -287,12 +287,12 @@ class TableauxController(
     } yield EmptyObject()
   }
 
-  def duplicateRow(tableId: TableId, rowId: RowId, linkOptions: Option[DuplicateLinkOption])(implicit user: TableauxUser): Future[Row] = {
+  def duplicateRow(tableId: TableId, rowId: RowId, duplicateOptions: Option[DuplicateRowOptions])(implicit user: TableauxUser): Future[Row] = {
     checkArguments(greaterZero(tableId), greaterZero(rowId))
     logger.info(s"duplicateRow $tableId $rowId")
     for {
       table <- repository.retrieveTable(tableId)
-      duplicated <- repository.duplicateRow(table, rowId, linkOptions)
+      duplicated <- repository.duplicateRow(table, rowId, duplicateOptions)
     } yield duplicated
   }
 

--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -7,6 +7,7 @@ import com.campudus.tableaux.database.{LanguageNeutral, LocationType}
 import com.campudus.tableaux.database.domain._
 import com.campudus.tableaux.database.domain.DisplayInfos.Langtag
 import com.campudus.tableaux.database.model.{Attachment, TableauxModel}
+import com.campudus.tableaux.database.model.DuplicateRowOptions
 import com.campudus.tableaux.database.model.TableauxModel._
 import com.campudus.tableaux.router.auth.permission._
 
@@ -17,7 +18,6 @@ import scala.concurrent.Future
 import scala.util.Try
 
 import java.util.UUID
-import com.campudus.tableaux.database.model.DuplicateRowOptions
 
 object TableauxController {
 
@@ -287,7 +287,8 @@ class TableauxController(
     } yield EmptyObject()
   }
 
-  def duplicateRow(tableId: TableId, rowId: RowId, duplicateOptions: Option[DuplicateRowOptions])(implicit user: TableauxUser): Future[Row] = {
+  def duplicateRow(tableId: TableId, rowId: RowId, duplicateOptions: Option[DuplicateRowOptions])(implicit
+  user: TableauxUser): Future[Row] = {
     checkArguments(greaterZero(tableId), greaterZero(rowId))
     logger.info(s"duplicateRow $tableId $rowId")
     for {

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -1079,7 +1079,7 @@ class TableauxModel(
       duplicatedRow <- retrieveRow(table, duplicatedRowId)
       _ <-
         if (shouldAnnotateSkipped) {
-          Future.sequence(skippedColumns.map(col =>
+          Future.sequence(skippedColumns.filter(canBeDuplicated).map(col =>
             addCellAnnotation(col, duplicatedRow.id, Seq.empty, CellAnnotationType(CellAnnotationType.FLAG), "check-me")
           ))
         } else Future.successful(())

--- a/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
+++ b/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
@@ -259,6 +259,13 @@ object JsonUtils extends LazyLogging {
     } yield result).get
   }
 
+  def toColumnSeq(json: JsonObject) = {
+    for {
+      columnsObject <- toJsonObjectSeq("columns", json)
+      columns = sequence(columnsObject.map(hasLong("id", _)))
+    } yield columns.get
+  }
+
   def toColumnValueSeq(json: JsonObject): Seq[Seq[(ColumnId, _)]] = {
     (for {
       columnsObject <- toJsonObjectSeq("columns", json)

--- a/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
+++ b/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
@@ -259,11 +259,11 @@ object JsonUtils extends LazyLogging {
     } yield result).get
   }
 
-  def toColumnSeq(json: JsonObject) = {
+  def toColumnIdSeq(json: JsonObject) = {
     for {
       columnsObject <- toJsonObjectSeq("columns", json)
       columns = sequence(columnsObject.map(hasLong("id", _)))
-    } yield columns.get
+    } yield columns
   }
 
   def toColumnValueSeq(json: JsonObject): Seq[Seq[(ColumnId, _)]] = {

--- a/src/main/scala/com/campudus/tableaux/router/BaseRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/BaseRouter.scala
@@ -154,6 +154,10 @@ trait BaseRouter extends VertxAccess {
     context.request().getParam(name).map(_.toLong)
   }
 
+  def getBoolParam(name: String, context: RoutingContext): Option[Boolean] = {
+    context.request().getParam(name).map(_.toBoolean)
+  }
+
   def getStringParam(name: String, context: RoutingContext): Option[String] = {
     context.request().getParam(name)
   }

--- a/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
@@ -3,6 +3,7 @@ package com.campudus.tableaux.router
 import com.campudus.tableaux.{InvalidJsonException, NoJsonFoundException, TableauxConfig}
 import com.campudus.tableaux.controller.TableauxController
 import com.campudus.tableaux.database.domain.{CellAnnotationType, Pagination}
+import com.campudus.tableaux.database.model.DuplicateLinkOption
 import com.campudus.tableaux.helper.JsonUtils._
 import com.campudus.tableaux.router.auth.permission.TableauxUser
 
@@ -556,6 +557,10 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
     */
   private def duplicateRow(context: RoutingContext): Unit = {
     implicit val user = TableauxUser(context)
+    val linkOptions = DuplicateLinkOption(
+      getBoolParam("skipConstrainedLinks", context).getOrElse(false),
+      getBoolParam("annotateSkipped", context).getOrElse(false)
+    )
     for {
       tableId <- getTableId(context)
       rowId <- getRowId(context)
@@ -563,7 +568,7 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
       sendReply(
         context,
         asyncGetReply {
-          controller.duplicateRow(tableId, rowId)
+          controller.duplicateRow(tableId, rowId, Some(linkOptions))
         }
       )
     }

--- a/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
@@ -562,7 +562,7 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
       body.filter(_.containsKey("columns"))
         .map(toColumnSeq)
         .map(_.get)
-     val duplicateOptions = DuplicateRowOptions(
+    val duplicateOptions = DuplicateRowOptions(
       getBoolParam("skipConstrainedLinks", context).getOrElse(false),
       getBoolParam("annotateSkipped", context).getOrElse(false),
       specificColumnsIds

--- a/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
@@ -1,6 +1,7 @@
 package com.campudus.tableaux.router
 
 import com.campudus.tableaux.{InvalidJsonException, NoJsonFoundException, TableauxConfig}
+import com.campudus.tableaux.OkArg
 import com.campudus.tableaux.controller.TableauxController
 import com.campudus.tableaux.database.domain.{CellAnnotationType, Pagination}
 import com.campudus.tableaux.database.model.DuplicateRowOptions
@@ -560,8 +561,12 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
     val body = Try(getJson(context)).toOption
     val specificColumnsIds =
       body.filter(_.containsKey("columns"))
-        .map(toColumnSeq)
-        .map(_.get)
+        .map(toColumnIdSeq)
+        .flatMap(_.toOption)
+        .flatMap(_ match {
+          case OkArg(value) => Some(value)
+          case _ => None
+        })
     val duplicateOptions = DuplicateRowOptions(
       getBoolParam("skipConstrainedLinks", context).getOrElse(false),
       getBoolParam("annotateSkipped", context).getOrElse(false),

--- a/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
@@ -1,11 +1,8 @@
 package com.campudus.tableaux.router
 
 import com.campudus.tableaux.{InvalidJsonException, NoJsonFoundException, TableauxConfig}
-import com.campudus.tableaux.ArgumentChecker
 import com.campudus.tableaux.controller.TableauxController
 import com.campudus.tableaux.database.domain.{CellAnnotationType, Pagination}
-import com.campudus.tableaux.database.domain.ColumnType
-import com.campudus.tableaux.database.domain.SimpleValueColumn
 import com.campudus.tableaux.database.model.DuplicateRowOptions
 import com.campudus.tableaux.helper.JsonUtils._
 import com.campudus.tableaux.router.auth.permission.TableauxUser
@@ -13,7 +10,6 @@ import com.campudus.tableaux.router.auth.permission.TableauxUser
 import io.vertx.scala.ext.web.{Router, RoutingContext}
 import io.vertx.scala.ext.web.handler.BodyHandler
 import org.vertx.scala.core.json.JsonArray
-import org.vertx.scala.core.json.JsonObject
 
 import scala.concurrent.Future
 import scala.util.Try

--- a/src/test/scala/com/campudus/tableaux/api/auth/TableauxControllerAuthTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/auth/TableauxControllerAuthTest.scala
@@ -977,7 +977,7 @@ class TableauxControllerAuthTest_row extends TableauxControllerAuthTest {
 
     for {
       _ <- createTestTable()
-      _ <- controller.duplicateRow(1, 1)
+      _ <- controller.duplicateRow(1, 1, None)
     } yield ()
   }
 
@@ -1009,7 +1009,7 @@ class TableauxControllerAuthTest_row extends TableauxControllerAuthTest {
         _ <- sendRequest("POST", "/system/settings/langtags", Json.obj("value" -> Json.arr("de", "en")))
 
         _ <- createTestTable()
-        duplicatedRow <- controller.duplicateRow(1, 1)
+        duplicatedRow <- controller.duplicateRow(1, 1, None)
 
         // Request with dev role to get al columns
         duplicatedRowAllColumns <- sendRequest("GET", s"/tables/1/rows/${duplicatedRow.id}")
@@ -1039,7 +1039,7 @@ class TableauxControllerAuthTest_row extends TableauxControllerAuthTest {
 
     for {
       _ <- createTestTable()
-      ex <- controller.duplicateRow(1, 1).recover({ case ex => ex })
+      ex <- controller.duplicateRow(1, 1, None).recover({ case ex => ex })
     } yield {
       assertEquals(UnauthorizedException(CreateRow, Seq("duplicate-rows")), ex)
     }

--- a/src/test/scala/com/campudus/tableaux/api/content/DuplicateRowTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/DuplicateRowTest.scala
@@ -1,14 +1,22 @@
 package com.campudus.tableaux.api.content
 
+import com.campudus.tableaux.database.domain.Cardinality
+import com.campudus.tableaux.database.domain.Constraint
+import com.campudus.tableaux.database.model.TableauxModel
+import com.campudus.tableaux.database.model.TableauxModel.TableId
+import com.campudus.tableaux.testtools.RequestCreation
 import com.campudus.tableaux.testtools.TableauxTestBase
 
 import io.vertx.ext.unit.TestContext
 import io.vertx.ext.unit.junit.VertxUnitRunner
 import org.vertx.scala.core.json.Json
 
+import scala.concurrent.Future
+
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
+import com.campudus.tableaux.database.domain.CellAnnotationType
 
 @RunWith(classOf[VertxUnitRunner])
 class DuplicateRowTest extends TableauxTestBase {
@@ -207,4 +215,60 @@ class DuplicateRowTest extends TableauxTestBase {
     }
   }
 
+  @Test
+  def skipConstrainedLinks(implicit c: TestContext): Unit = okTest {
+    for {
+      tableIds <- createLinkedTables()
+      modelTableId = tableIds(0)
+      _ <- sendRequest("POST", s"/tables/$modelTableId/rows/1/duplicate?skipConstrainedLinks=true")
+      rowRes <- sendRequest("GET", s"/tables/$modelTableId/rows")
+      annotationRes <- sendRequest("GET", s"/tables/$modelTableId/columns/3/rows/3/annotations")
+    } yield {
+      val rows = rowRes.getJsonArray("rows")
+      val originalValues = rows.getJsonObject(0).getJsonArray("values")
+      val duplicatedValues = rows.getJsonObject(2).getJsonArray("values")
+
+      assertEquals(originalValues.getString(0), duplicatedValues.getString(0))
+      assertEquals(1, originalValues.getJsonArray(2).size()) // original had a link
+      assertEquals(0, duplicatedValues.getJsonArray(2).size()) // duplicate does not have it
+      assertEquals(null, annotationRes.getJsonArray("annotations").getJsonObject(0)) // no annotations set
+    }
+  }
+
+  @Test
+  def skipAndAnnotateConstrainedLinks(implicit c: TestContext): Unit = okTest {
+    for {
+      tableIds <- createLinkedTables()
+      modelTableId = tableIds(0)
+      _ <- sendRequest("POST", s"/tables/$modelTableId/rows/1/duplicate?skipConstrainedLinks=true&annotateSkipped=true")
+      res <- sendRequest("GET", s"/tables/$modelTableId/columns/3/rows/3/annotations")
+      _ = println(res)
+    } yield {
+      val checkMeAnnotation = res.getJsonArray("annotations").getJsonArray(0).getJsonObject(0)
+      assertEquals(checkMeAnnotation.getString("type"), CellAnnotationType.FLAG)
+      assertEquals(checkMeAnnotation.getString("value"), "check-me")
+    }
+  }
+
+  def createLinkedTables(): Future[Seq[TableId]] = {
+    for {
+      modelTableId <- createDefaultTable(name = "models")
+      variantTableId <- createDefaultTable(name = "variants")
+      addLinkColumn = RequestCreation.Columns(
+        RequestCreation.LinkBiDirectionalCol(
+          "variant",
+          variantTableId,
+          Constraint(new Cardinality(1, 0), deleteCascade = false)
+        )
+      )
+      _ <- sendRequest("POST", s"/tables/$modelTableId/columns", addLinkColumn)
+      _ <- sendRequest(
+        "POST",
+        s"/tables/$modelTableId/columns/3/rows/1",
+        Json.obj("value" -> Json.arr(1))
+      )
+    } yield (
+      Seq(modelTableId, variantTableId)
+    )
+  }
 }


### PR DESCRIPTION
Modifies the `/tables/:tableId/rows/:rowId/duplicate` endpoint to take options:

- Optional JSON-body `{columns: Array<{id: ColumnId}>}` will duplicate only the values of those columns.
- Optional boolean query parameter `skipConstrainedLinks` will skip duplicating values of link cells with constrained `from`-cardinality. When set, constrained link cell will not be duplicated, even if listed in the JSON-body payload.
- Optional boolean query parameter `annotateSkipped` will add a `check-me` annotation to all cells whose values were not duplicated.