### PR TITLE
AC#1033/fix-in-translation-endpoint

### DIFF
--- a/src/main/scala/com/campudus/tableaux/cache/CacheVerticle.scala
+++ b/src/main/scala/com/campudus/tableaux/cache/CacheVerticle.scala
@@ -73,14 +73,13 @@ class CacheVerticle extends ScalaVerticle with LazyLogging {
   private def getCache(tableId: TableId, columnId: ColumnId): Cache[AnyRef] = {
 
     def createCache() = {
-      val builder = CacheBuilder
-        .newBuilder()
+      val builder = CacheBuilder.newBuilder()
 
       val expireAfterAccess = config.getLong("expireAfterAccess", DEFAULT_EXPIRE_AFTER_ACCESS).toLong
       if (expireAfterAccess > 0) {
         builder.expireAfterAccess(expireAfterAccess, TimeUnit.SECONDS)
       } else {
-        logger.info("Cache will not expire!")
+        logger.debug("Cache will not expire!")
       }
 
       val maximumSize = config.getLong("maximumSize", DEFAULT_MAXIMUM_SIZE).toLong

--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -232,7 +232,12 @@ class TableauxController(
           })
           .map(_._2)
 
-        (langtag, mergedTranslationStatusForLangtag.sum / mergedTranslationStatusForLangtag.size)
+        val calculatedLangtagStatus = mergedTranslationStatusForLangtag.size match {
+          case 0 => 1
+          case _ => mergedTranslationStatusForLangtag.sum / mergedTranslationStatusForLangtag.size
+        }
+
+        (langtag, calculatedLangtagStatus)
       })
 
       PlainDomainObject(

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -1248,7 +1248,9 @@ class TableauxModel(
   )(implicit user: TableauxUser): Future[Boolean] = {
     roleModel.checkAuthorization(
       ViewRow,
-      ComparisonObjects(permissions)
+      ComparisonObjects(permissions),
+      isInternalCall = false,
+      shouldLog = false
     ) transform {
       case Success(_) => Success(true)
       case Failure(_) => Success(false)

--- a/src/main/scala/com/campudus/tableaux/database/model/tableaux/RowModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/tableaux/RowModel.scala
@@ -1047,7 +1047,12 @@ class RetrieveRowModel(val connection: DatabaseConnection)(
       .mkString("", " UNION ALL ", " ORDER BY table_id, type, type_value, last_created_at DESC")
 
     for {
-      result <- connection.query(query)
+      result <-
+        if (tables.isEmpty) {
+          Future.successful(Json.emptyObj())
+        } else {
+          connection.query(query)
+        }
     } yield {
       resultObjectToJsonArray(result)
         .map(jsonArrayToSeq)

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/RoleModel.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/RoleModel.scala
@@ -59,7 +59,8 @@ class RoleModel(jsonObject: JsonObject) extends LazyLogging {
   def checkAuthorization(
       action: Action,
       objects: ComparisonObjects = ComparisonObjects(),
-      isInternalCall: Boolean = false
+      isInternalCall: Boolean = false,
+      shouldLog: Boolean = true
   )(implicit user: TableauxUser): Future[Unit] = {
 
     if (isInternalCall) {
@@ -71,7 +72,7 @@ class RoleModel(jsonObject: JsonObject) extends LazyLogging {
         Future.successful(())
       } else {
         val userName = user.name
-        logger.info(s"User ${userName} is not allowed to do action '$action'")
+        if (shouldLog) logger.info(s"User ${userName} is not allowed to do action '$action'")
         Future.failed(UnauthorizedException(action, userRoles))
       }
     }
@@ -411,7 +412,12 @@ class RoleModel(jsonObject: JsonObject) extends LazyLogging {
   */
 class RoleModelStub extends RoleModel(Json.emptyObj()) with LazyLogging {
 
-  override def checkAuthorization(action: Action, objects: ComparisonObjects, isInternalCall: Boolean)(
+  override def checkAuthorization(
+      action: Action,
+      objects: ComparisonObjects,
+      isInternalCall: Boolean,
+      shouldLog: Boolean
+  )(
       implicit user: TableauxUser
   ): Future[Unit] = {
     Future.successful(())

--- a/src/test/scala/com/campudus/tableaux/api/content/TranslationStatusTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/TranslationStatusTest.scala
@@ -184,4 +184,25 @@ class TranslationStatusTest extends TableauxTestBase {
       }
     }
   }
+
+  @Test
+  def retrieveTranslationStatusWithoutAnyMultilangColumn(implicit c: TestContext) = okTest {
+
+    for {
+      tableId <- createDefaultTable()
+      translationStatus <- sendRequest("GET", s"/tables/translationStatus")
+    } yield {
+
+      println(s"translationStatus: $translationStatus")
+      val expectedTranslationStatus = Json.obj(
+        "tables" -> Json.emptyArr(),
+        "translationStatus" -> Json.obj(
+          "de-DE" -> 1.0,
+          "en-GB" -> 1.0
+        )
+      )
+
+      assertJSONEquals(expectedTranslationStatus, translationStatus)
+    }
+  }
 }


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

In dem Zuge hab ich auch das logging verbessert und im backend wird nicht mehr gelogged, wenn man eine Zeile per `retrieveForeignRows` nicht sehen darf. Durch die Rekursion und bei vielen Ausgangszeilen würde das nämlich die logs einfach nur voll spammen. 

Das Dashboard hat mit der Änderung kein Problem mehr und rendert auch, wenn es nicht eine multicolumn Spalte gibt. Die Seite ist dann zwar witzlos, aber es wird auch nichts falsches angezeigt:

![image](https://github.com/campudus/tableaux/assets/148202/b3852061-6046-4f86-b284-992422e49502)