### PR TITLE
allow to overwrite openApiUrl per settings

### DIFF
--- a/conf-example.json
+++ b/conf-example.json
@@ -5,6 +5,7 @@
   "uploadsDirectory": "uploads/",
   "workingDirectory": "./",
   "rolePermissionsPath": "./role-permissions.json",
+  "openApiUrl": "https://my.domain.com/api/docs",
 
   "database" : {
     "host" : "localhost",

--- a/src/main/scala/com/campudus/tableaux/Starter.scala
+++ b/src/main/scala/com/campudus/tableaux/Starter.scala
@@ -53,7 +53,7 @@ class Starter extends ScalaVerticle with LazyLogging {
       val uploadsDirectory = getStringDefault(config, "uploadsDirectory", Starter.DEFAULT_UPLOADS_DIRECTORY)
       val authConfig = config.getJsonObject("auth", Json.obj())
       val rolePermissionsPath = getStringDefault(config, "rolePermissionsPath", Starter.DEFAULT_ROLE_PERMISSIONS_PATH)
-      val openApiUrl = getStringDefault(config, "openApiUrl", "")
+      val openApiUrl = Option(getStringDefault(config, "openApiUrl", null))
 
       val rolePermissions = FileUtils(vertxAccessContainer()).readJsonFile(rolePermissionsPath, Json.emptyObj())
 

--- a/src/main/scala/com/campudus/tableaux/Starter.scala
+++ b/src/main/scala/com/campudus/tableaux/Starter.scala
@@ -53,6 +53,7 @@ class Starter extends ScalaVerticle with LazyLogging {
       val uploadsDirectory = getStringDefault(config, "uploadsDirectory", Starter.DEFAULT_UPLOADS_DIRECTORY)
       val authConfig = config.getJsonObject("auth", Json.obj())
       val rolePermissionsPath = getStringDefault(config, "rolePermissionsPath", Starter.DEFAULT_ROLE_PERMISSIONS_PATH)
+      val openApiUrl = getStringDefault(config, "openApiUrl", "")
 
       val rolePermissions = FileUtils(vertxAccessContainer()).readJsonFile(rolePermissionsPath, Json.emptyObj())
 
@@ -62,7 +63,8 @@ class Starter extends ScalaVerticle with LazyLogging {
         authConfig = authConfig,
         workingDirectory = workingDirectory,
         uploadsDirectory = uploadsDirectory,
-        rolePermissions = rolePermissions
+        rolePermissions = rolePermissions,
+        openApiUrl = openApiUrl
       )
 
       connection = SQLConnection(vertxAccessContainer(), databaseConfig)

--- a/src/main/scala/com/campudus/tableaux/TableauxConfig.scala
+++ b/src/main/scala/com/campudus/tableaux/TableauxConfig.scala
@@ -14,7 +14,7 @@ class TableauxConfig(
     workingDirectory: String,
     uploadsDirectory: String,
     val rolePermissions: JsonObject,
-    val openApiUrl: String = ""
+    val openApiUrl: Option[String] = None
 ) extends VertxAccess {
 
   def uploadsDirectoryPath(): Path = {

--- a/src/main/scala/com/campudus/tableaux/TableauxConfig.scala
+++ b/src/main/scala/com/campudus/tableaux/TableauxConfig.scala
@@ -13,6 +13,7 @@ class TableauxConfig(
     databaseConfig: JsonObject,
     workingDirectory: String,
     uploadsDirectory: String,
+    val openApiUrl: String,
     val rolePermissions: JsonObject
 ) extends VertxAccess {
 

--- a/src/main/scala/com/campudus/tableaux/TableauxConfig.scala
+++ b/src/main/scala/com/campudus/tableaux/TableauxConfig.scala
@@ -13,8 +13,8 @@ class TableauxConfig(
     databaseConfig: JsonObject,
     workingDirectory: String,
     uploadsDirectory: String,
-    val openApiUrl: String,
-    val rolePermissions: JsonObject
+    val rolePermissions: JsonObject,
+    val openApiUrl: String = ""
 ) extends VertxAccess {
 
   def uploadsDirectoryPath(): Path = {

--- a/src/main/scala/com/campudus/tableaux/router/DocumentationRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/DocumentationRouter.scala
@@ -130,10 +130,12 @@ class DocumentationRouter(override val config: TableauxConfig) extends BaseRoute
       })
 
     val forwardedUrl = request.getHeader("x-forwarded-url")
+    val openApiUrl = config.openApiUrl
 
-    val uri = (forwardedScheme, forwardedHost, forwardedUrl) match {
-      case (Some(scheme), Some(host), Some(query)) => s"$scheme://$host$query"
-      case _ => config.openApiUrl
+    val uri = (forwardedScheme, forwardedHost, forwardedUrl, openApiUrl) match {
+      case (Some(scheme), Some(host), Some(query), _) => s"$scheme://$host$query"
+      case (_, _, _, Some(openApiUrl)) => openApiUrl
+      case _ => request.absoluteURI()
     }
 
     DocUriParser.parse(uri)

--- a/src/main/scala/com/campudus/tableaux/router/DocumentationRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/DocumentationRouter.scala
@@ -133,7 +133,7 @@ class DocumentationRouter(override val config: TableauxConfig) extends BaseRoute
 
     val uri = (forwardedScheme, forwardedHost, forwardedUrl) match {
       case (Some(scheme), Some(host), Some(query)) => s"$scheme://$host$query"
-      case _ => request.absoluteURI()
+      case _ => config.openApiUrl
     }
 
     DocUriParser.parse(uri)


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

Falls die automatische Generierung der api url aus Gründen nicht funktioniert (z.B. wegen traefik proxy), kann die url auch per backend config gesetzt werden. Siehe `conf-example.json`