### PR TITLE
fix/filter-total-size-queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ project/plugins/project/
 
 # local log properties
 local_logging.properties
+
+*.local*

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -11,7 +11,7 @@
     - [Retrieving a specific column](#retrieving-a-specific-column)
     - [Retrieving a specific row](#retrieving-a-specific-row)
     - [Retrieving a specific cell](#retrieving-a-specific-cell)
-  - [2.2. Data types & column kinds](#22-data-types--column-kinds)
+  - [2.2. Data types \& column kinds](#22-data-types--column-kinds)
     - [Primitive data types](#primitive-data-types)
       - [Examples](#examples)
     - [Complex data types](#complex-data-types)
@@ -155,7 +155,7 @@ Call this endpoint to retrieve all rows of a specific table. Most important part
   "page": { // result can be paged with two query parameters offset and limit
     "offset": null,
     "limit": null,
-    "totalSize": 18 // total size of this table
+    "totalSize": 18 // total number of rows depending on filter query parameters. If no filters are set, totalSize is the total number of rows in the table
   },
   "rows": [
     { // row object

--- a/src/main/resources/swagger.json
+++ b/src/main/resources/swagger.json
@@ -2238,6 +2238,7 @@
               "example": 100
             },
             "totalSize": {
+              "description": "Total number of rows depending on filter query parameters. If no filters are set, totalSize is the total number of rows in the table",
               "type": "integer",
               "example": 315
             }

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -1327,7 +1327,7 @@ class TableauxModel(
       implicit user: TableauxUser
   ): Future[RowSeq] = {
     for {
-      totalSize <- retrieveRowModel.size(table.id)
+      totalSize <- retrieveRowModel.size(table.id, finalFlagOpt, archivedFlagOpt)
       rawRows <- retrieveRowModel.retrieveAll(table.id, columns, finalFlagOpt, archivedFlagOpt, pagination)
       rowSeq <- mapRawRows(table, columns, rawRows)
     } yield {
@@ -1575,8 +1575,12 @@ class TableauxModel(
     } yield values
   }
 
-  def retrieveTotalSize(table: Table): Future[Long] = {
-    retrieveRowModel.size(table.id)
+  def retrieveTotalSize(
+      table: Table,
+      finalFlagOpt: Option[Boolean] = None,
+      archivedFlagOpt: Option[Boolean] = None
+  ): Future[Long] = {
+    retrieveRowModel.size(table.id, finalFlagOpt, archivedFlagOpt)
   }
 
   def retrieveCellHistory(

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -1235,7 +1235,7 @@ class TableauxModel(
         })
 
       (_, linkDirection, _) <- structureModel.columnStruc.retrieveLinkInformation(table, linkColumn.id)
-      totalSize <- retrieveRowModel.sizeForeign(linkColumn, rowId, linkDirection)
+      totalSize <- retrieveRowModel.sizeForeign(linkColumn, rowId, linkDirection, finalFlagOpt, archivedFlagOpt)
       rawRows <- retrieveRowModel.retrieveForeign(
         linkColumn,
         rowId,

--- a/src/main/scala/com/campudus/tableaux/database/model/tableaux/RowModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/tableaux/RowModel.scala
@@ -1279,10 +1279,11 @@ class RetrieveRowModel(val connection: DatabaseConnection)(
     }
   }
 
-  def size(tableId: TableId): Future[Long] = {
-    val select = s"SELECT COUNT(*) FROM user_table_$tableId"
+  def size(tableId: TableId, finalFlagOpt: Option[Boolean], archivedFlagOpt: Option[Boolean]): Future[Long] = {
+    val whereClause = generateRowAnnotationWhereClause(finalFlagOpt, archivedFlagOpt)
+    val query = s"SELECT COUNT(*) FROM user_table_$tableId WHERE TRUE $whereClause"
 
-    connection.selectSingleValue(select)
+    connection.selectSingleValue(query)
   }
 
   def sizeForeign(linkColumn: LinkColumn, rowId: RowId, linkDirection: LinkDirection): Future[Long] = {

--- a/src/test/scala/com/campudus/tableaux/api/content/LinkConstraintTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/LinkConstraintTest.scala
@@ -1704,6 +1704,7 @@ class RetrieveFinalAndArchivedRows extends LinkTestBase with Helper {
 
         resultCell <- sendRequest("GET", s"/tables/$tableId1/columns/$linkColumnId/rows/$rowId1")
 
+        resultAllForeignRows <- sendRequest("GET", s"/tables/$tableId1/columns/$linkColumnId/rows/$rowId1/foreignRows")
         resultForeignRowsFinal <-
           sendRequest("GET", s"/tables/$tableId1/columns/$linkColumnId/rows/$rowId1/foreignRows?final=true")
         resultForeignRowsArchived <-
@@ -1711,8 +1712,11 @@ class RetrieveFinalAndArchivedRows extends LinkTestBase with Helper {
       } yield {
         assertEquals(0, resultCell.getJsonArray("value").size())
 
-        assertEquals(2, resultForeignRowsFinal.getJsonObject("page").getLong("totalSize").longValue())
-        assertEquals(2, resultForeignRowsArchived.getJsonObject("page").getLong("totalSize").longValue())
+        assertEquals(2, resultAllForeignRows.getJsonObject("page").getLong("totalSize").longValue())
+        assertJSONEquals(Json.arr(Json.obj("id" -> 1), Json.obj("id" -> 2)), resultAllForeignRows.getJsonArray("rows"))
+
+        assertEquals(1, resultForeignRowsFinal.getJsonObject("page").getLong("totalSize").longValue())
+        assertEquals(1, resultForeignRowsArchived.getJsonObject("page").getLong("totalSize").longValue())
         assertJSONEquals(Json.arr(Json.obj("id" -> 1)), resultForeignRowsFinal.getJsonArray("rows"))
         assertJSONEquals(Json.arr(Json.obj("id" -> 2)), resultForeignRowsArchived.getJsonArray("rows"))
       }

--- a/src/test/scala/com/campudus/tableaux/api/content/LinkTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/LinkTest.scala
@@ -1178,21 +1178,23 @@ class LinkTest extends LinkTestBase {
           js.getJsonArray("columns")
         }
       } yield {
-        val expectedJson = Json.fromObjectString(s"""
-                                                    |{
-                                                    |  "status": "ok",
-                                                    |  "page": {
-                                                    |    "offset": null,
-                                                    |    "limit": null,
-                                                    |    "totalSize": 3
-                                                    |  },
-                                                    |  "rows": [
-                                                    |    {"id": 1,"values": [[{"id": 2,"value": "blub 2"}]]},
-                                                    |    {"id": 2,"values": [[{"id": 3,"value": "blub 3"}]]},
-                                                    |    {"id": 3,"values": [[{"id": 1,"value": "blub 1"}]]}
-                                                    |  ]
-                                                    |}
-         """.stripMargin)
+        val expectedJson = Json.fromObjectString(
+          s"""
+             |{
+             |  "status": "ok",
+             |  "page": {
+             |    "offset": null,
+             |    "limit": null,
+             |    "totalSize": 3
+             |  },
+             |  "rows": [
+             |    {"id": 1,"values": [[{"id": 2,"value": "blub 2"}]]},
+             |    {"id": 2,"values": [[{"id": 3,"value": "blub 3"}]]},
+             |    {"id": 3,"values": [[{"id": 1,"value": "blub 1"}]]}
+             |  ]
+             |}
+         """.stripMargin
+        )
 
         assertJSONEquals(expectedJson, rows)
 


### PR DESCRIPTION
Wie in PR https://github.com/campudus/tableaux-frontend/pull/381 erwähnt, sollte die totalSize von den Filtern abhängen und nicht nur die Kardinalität der Tabelle wiedergeben.
Siehe Comment Punkt #5: https://github.com/campudus/tableaux-frontend/pull/381#issuecomment-2117460068