### PR TITLE
Speedup test db schema

### DIFF
--- a/src/main/resources/schema/merged_schema_until_v35.sql
+++ b/src/main/resources/schema/merged_schema_until_v35.sql
@@ -1,0 +1,297 @@
+
+
+CREATE TABLE public.file (
+    uuid uuid NOT NULL,
+    idfolder bigint,
+    tmp boolean DEFAULT true NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone
+);
+
+CREATE TABLE public.file_lang (
+    uuid uuid NOT NULL,
+    langtag character varying(50) NOT NULL,
+    title character varying(255),
+    description character varying(255),
+    internal_name character varying(255),
+    external_name character varying(255),
+    mime_type character varying(255)
+);
+
+CREATE TABLE public.folder (
+    id bigint NOT NULL,
+    name character varying(255) NOT NULL,
+    description character varying(255) NOT NULL,
+    idparent bigint,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone
+);
+
+CREATE SEQUENCE public.folder_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.folder_id_seq OWNED BY public.folder.id;
+
+CREATE TABLE public.system_attachment (
+    table_id bigint NOT NULL,
+    column_id bigint NOT NULL,
+    row_id bigint NOT NULL,
+    attachment_uuid uuid NOT NULL,
+    ordering bigint NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone
+);
+
+CREATE TABLE public.system_column_groups (
+    table_id bigint NOT NULL,
+    group_column_id bigint NOT NULL,
+    grouped_column_id bigint NOT NULL
+);
+
+CREATE TABLE public.system_columns (
+    table_id bigint NOT NULL,
+    column_id bigint NOT NULL,
+    column_type character varying(255) NOT NULL,
+    user_column_name character varying(255) NOT NULL,
+    ordering bigint NOT NULL,
+    link_id bigint,
+    multilanguage character varying(255),
+    identifier boolean DEFAULT false,
+    country_codes text[],
+    format_pattern character varying(255),
+    separator boolean DEFAULT false NOT NULL,
+    attributes json DEFAULT '{}'::json NOT NULL,
+    rules json DEFAULT '[]'::json NOT NULL,
+    hidden boolean DEFAULT false NOT NULL,
+    max_length integer,
+    min_length integer
+);
+
+CREATE TABLE public.system_columns_lang (
+    table_id bigint NOT NULL,
+    column_id bigint NOT NULL,
+    langtag character varying(50) NOT NULL,
+    name character varying(255),
+    description text
+);
+
+CREATE TABLE public.system_link_table (
+    link_id bigint NOT NULL,
+    table_id_1 bigint,
+    table_id_2 bigint,
+    cardinality_1 integer DEFAULT 0,
+    cardinality_2 integer DEFAULT 0,
+    delete_cascade boolean DEFAULT false,
+    archive_cascade boolean DEFAULT false,
+    final_cascade boolean DEFAULT false,
+    CONSTRAINT system_link_table_cardinality_1_check CHECK ((cardinality_1 >= 0)),
+    CONSTRAINT system_link_table_cardinality_2_check CHECK ((cardinality_2 >= 0))
+);
+
+CREATE SEQUENCE public.system_link_table_link_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.system_link_table_link_id_seq OWNED BY public.system_link_table.link_id;
+
+CREATE TABLE public.system_services (
+    id bigint NOT NULL,
+    type character varying(50) NOT NULL,
+    name character varying(255) NOT NULL,
+    ordering bigint,
+    displayname json,
+    description json,
+    active boolean DEFAULT true,
+    config jsonb,
+    scope jsonb,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp without time zone
+);
+
+CREATE SEQUENCE public.system_services_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.system_services_id_seq OWNED BY public.system_services.id;
+
+CREATE TABLE public.system_settings (
+    key character varying(255) NOT NULL,
+    value text
+);
+
+CREATE TABLE public.system_table (
+    table_id bigint NOT NULL,
+    user_table_name character varying(255) NOT NULL,
+    is_hidden boolean DEFAULT false,
+    ordering bigint,
+    langtags text[],
+    type text,
+    group_id bigint,
+    attributes json DEFAULT '{}'::json NOT NULL
+);
+
+CREATE TABLE public.system_table_lang (
+    table_id bigint NOT NULL,
+    langtag character varying(50) NOT NULL,
+    name character varying(255),
+    description text
+);
+
+CREATE SEQUENCE public.system_table_table_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.system_table_table_id_seq OWNED BY public.system_table.table_id;
+
+CREATE TABLE public.system_tablegroup (
+    id bigint NOT NULL
+);
+
+CREATE SEQUENCE public.system_tablegroup_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE public.system_tablegroup_id_seq OWNED BY public.system_tablegroup.id;
+
+CREATE TABLE public.system_tablegroup_lang (
+    id bigint NOT NULL,
+    langtag character varying(50) NOT NULL,
+    name character varying(255),
+    description text
+);
+
+ALTER TABLE ONLY public.folder ALTER COLUMN id SET DEFAULT nextval('public.folder_id_seq'::regclass);
+
+ALTER TABLE ONLY public.system_link_table ALTER COLUMN link_id SET DEFAULT nextval('public.system_link_table_link_id_seq'::regclass);
+
+ALTER TABLE ONLY public.system_services ALTER COLUMN id SET DEFAULT nextval('public.system_services_id_seq'::regclass);
+
+ALTER TABLE ONLY public.system_table ALTER COLUMN table_id SET DEFAULT nextval('public.system_table_table_id_seq'::regclass);
+
+ALTER TABLE ONLY public.system_table ALTER COLUMN ordering SET DEFAULT currval('public.system_table_table_id_seq'::regclass);
+
+ALTER TABLE ONLY public.system_tablegroup ALTER COLUMN id SET DEFAULT nextval('public.system_tablegroup_id_seq'::regclass);
+
+
+INSERT INTO public.system_settings (key, value) VALUES ('langtags', '["de-DE", "en-GB"]');
+
+ALTER TABLE ONLY public.file_lang
+    ADD CONSTRAINT file_lang_pkey PRIMARY KEY (uuid, langtag);
+
+ALTER TABLE ONLY public.file
+    ADD CONSTRAINT file_pkey PRIMARY KEY (uuid);
+
+ALTER TABLE ONLY public.folder
+    ADD CONSTRAINT folder_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.system_attachment
+    ADD CONSTRAINT system_attachment_pkey PRIMARY KEY (table_id, column_id, row_id, attachment_uuid);
+
+ALTER TABLE ONLY public.system_column_groups
+    ADD CONSTRAINT system_column_groups_pkey PRIMARY KEY (table_id, group_column_id, grouped_column_id);
+
+ALTER TABLE ONLY public.system_columns_lang
+    ADD CONSTRAINT system_columns_lang_pkey PRIMARY KEY (table_id, column_id, langtag);
+
+ALTER TABLE ONLY public.system_columns
+    ADD CONSTRAINT system_columns_pkey PRIMARY KEY (table_id, column_id);
+
+ALTER TABLE ONLY public.system_link_table
+    ADD CONSTRAINT system_link_table_pkey PRIMARY KEY (link_id);
+
+ALTER TABLE ONLY public.system_services
+    ADD CONSTRAINT system_services_name_key UNIQUE (name);
+
+ALTER TABLE ONLY public.system_services
+    ADD CONSTRAINT system_services_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY public.system_settings
+    ADD CONSTRAINT system_settings_pkey PRIMARY KEY (key);
+
+ALTER TABLE ONLY public.system_table_lang
+    ADD CONSTRAINT system_table_lang_pkey PRIMARY KEY (table_id, langtag);
+
+ALTER TABLE ONLY public.system_table
+    ADD CONSTRAINT system_table_pkey PRIMARY KEY (table_id);
+
+ALTER TABLE ONLY public.system_tablegroup_lang
+    ADD CONSTRAINT system_tablegroup_lang_pkey PRIMARY KEY (id, langtag);
+
+ALTER TABLE ONLY public.system_tablegroup
+    ADD CONSTRAINT system_tablegroup_pkey PRIMARY KEY (id);
+
+CREATE UNIQUE INDEX system_columns_name ON public.system_columns USING btree (table_id, user_column_name);
+
+CREATE UNIQUE INDEX system_folder_name ON public.folder USING btree (name, idparent);
+
+CREATE UNIQUE INDEX system_table_name ON public.system_table USING btree (user_table_name);
+
+ALTER TABLE ONLY public.file
+    ADD CONSTRAINT file_idfolder_fkey FOREIGN KEY (idfolder) REFERENCES public.folder(id);
+
+ALTER TABLE ONLY public.file_lang
+    ADD CONSTRAINT file_lang_uuid_fkey FOREIGN KEY (uuid) REFERENCES public.file(uuid) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.folder
+    ADD CONSTRAINT folder_idparent_fkey FOREIGN KEY (idparent) REFERENCES public.folder(id);
+
+ALTER TABLE ONLY public.system_attachment
+    ADD CONSTRAINT system_attachment_attachment_uuid_fkey FOREIGN KEY (attachment_uuid) REFERENCES public.file(uuid) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_attachment
+    ADD CONSTRAINT system_attachment_table_id_column_id_fkey FOREIGN KEY (table_id, column_id) REFERENCES public.system_columns(table_id, column_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_attachment
+    ADD CONSTRAINT system_attachment_table_id_fkey FOREIGN KEY (table_id) REFERENCES public.system_table(table_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_column_groups
+    ADD CONSTRAINT system_column_groups_table_id_fkey FOREIGN KEY (table_id) REFERENCES public.system_table(table_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_column_groups
+    ADD CONSTRAINT system_column_groups_table_id_group_column_id_fkey FOREIGN KEY (table_id, group_column_id) REFERENCES public.system_columns(table_id, column_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_column_groups
+    ADD CONSTRAINT system_column_groups_table_id_grouped_column_id_fkey FOREIGN KEY (table_id, grouped_column_id) REFERENCES public.system_columns(table_id, column_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_columns_lang
+    ADD CONSTRAINT system_columns_lang_table_id_column_id_fkey FOREIGN KEY (table_id, column_id) REFERENCES public.system_columns(table_id, column_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_columns_lang
+    ADD CONSTRAINT system_columns_lang_table_id_fkey FOREIGN KEY (table_id) REFERENCES public.system_table(table_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_columns
+    ADD CONSTRAINT system_columns_link_id_fkey FOREIGN KEY (link_id) REFERENCES public.system_link_table(link_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_columns
+    ADD CONSTRAINT system_columns_table_id_fkey FOREIGN KEY (table_id) REFERENCES public.system_table(table_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_link_table
+    ADD CONSTRAINT system_link_table_table_id_1_fkey FOREIGN KEY (table_id_1) REFERENCES public.system_table(table_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_link_table
+    ADD CONSTRAINT system_link_table_table_id_2_fkey FOREIGN KEY (table_id_2) REFERENCES public.system_table(table_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_table
+    ADD CONSTRAINT system_table_group_id_fkey FOREIGN KEY (group_id) REFERENCES public.system_tablegroup(id) ON UPDATE CASCADE ON DELETE SET NULL;
+
+ALTER TABLE ONLY public.system_table_lang
+    ADD CONSTRAINT system_table_lang_table_id_fkey FOREIGN KEY (table_id) REFERENCES public.system_table(table_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.system_tablegroup_lang
+    ADD CONSTRAINT system_tablegroup_lang_id_fkey FOREIGN KEY (id) REFERENCES public.system_tablegroup(id) ON DELETE CASCADE;

--- a/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
@@ -101,6 +101,7 @@ class SystemController(
     for {
       _ <- roleModel.checkAuthorization(EditSystem)
       _ <- repository.uninstall()
+      _ <- repository.installShortCutFunction()
       _ <- repository.install()
       _ <- invalidateCache()
       _ <- structureModel.columnStruc.removeAllCache()

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -20,24 +20,47 @@ object SystemModel {
 class SystemModel(override protected[this] val connection: DatabaseConnection) extends DatabaseQuery {
 
   /**
-    * Runs all setup functions.
+    * Runs all needed setup functions.
     */
   def install(version: Option[Int] = None): Future[Unit] = {
     for {
       t <- connection.begin()
 
       // retrieve but ignore version
-      (t, _) <- retrieveCurrentVersion(t)
+      (t, installedVersions) <- retrieveCurrentVersion(t)
 
       t <- version
         .map(i => setupFunctions.take(i))
         .getOrElse(setupFunctions)
+        .drop(installedVersions)
         .foldLeft(Future(t)) {
           case (t, setup) =>
             t.flatMap(setup)
         }
 
       _ = logger.info("Setup schema finished")
+
+      _ <- t.commit()
+    } yield ()
+  }
+
+  /**
+    * Runs all setup functions.
+    */
+  def installShortCutFunction(): Future[Unit] = {
+    for {
+      t <- connection.begin()
+
+      // retrieve but ignore version
+      (t, _) <- retrieveCurrentVersion(t)
+
+      t <- setupShortCutFunction
+        .foldLeft(Future(t)) {
+          case (t, setup) =>
+            t.flatMap(setup)
+        }
+
+      _ = logger.info("Setup shortcut schema finished")
 
       _ <- t.commit()
     } yield ()
@@ -127,6 +150,44 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
   }
 
   private val setupFunctions: Seq[DbTransaction => Future[DbTransaction]] = Seq(
+    setupVersion(readSchemaFile("schema_v1"), 1),
+    setupVersion(readSchemaFile("schema_v2"), 2),
+    setupVersion(readSchemaFile("schema_v3"), 3),
+    setupVersion(readSchemaFile("schema_v4"), 4),
+    setupVersion(readSchemaFile("schema_v5"), 5),
+    setupVersion(readSchemaFile("schema_v6"), 6),
+    setupVersion(readSchemaFile("schema_v7"), 7),
+    setupVersion(readSchemaFile("schema_v8"), 8),
+    setupVersion(readSchemaFile("schema_v9"), 9),
+    setupVersion(readSchemaFile("schema_v10"), 10),
+    setupVersion(readSchemaFile("schema_v11"), 11),
+    setupVersion(readSchemaFile("schema_v12"), 12),
+    setupVersion(readSchemaFile("schema_v13"), 13),
+    setupVersion(readSchemaFile("schema_v14"), 14),
+    setupVersion(readSchemaFile("schema_v15"), 15),
+    setupVersion(readSchemaFile("schema_v16"), 16),
+    setupVersion(readSchemaFile("schema_v17"), 17),
+    setupVersion(readSchemaFile("schema_v18"), 18),
+    setupVersion(readSchemaFile("schema_v19"), 19),
+    setupVersion(readSchemaFile("schema_v20"), 20),
+    setupVersion(readSchemaFile("schema_v21"), 21),
+    setupVersion(readSchemaFile("schema_v22"), 22),
+    setupVersion(readSchemaFile("schema_v23"), 23),
+    setupVersion(readSchemaFile("schema_v24"), 24),
+    setupVersion(readSchemaFile("schema_v25"), 25),
+    setupVersion(readSchemaFile("schema_v26"), 26),
+    setupVersion(readSchemaFile("schema_v27"), 27),
+    setupVersion(readSchemaFile("schema_v28"), 28),
+    setupVersion(readSchemaFile("schema_v29"), 29),
+    setupVersion(readSchemaFile("schema_v30"), 30),
+    setupVersion(readSchemaFile("schema_v31"), 31),
+    setupVersion(readSchemaFile("schema_v32"), 32),
+    setupVersion(readSchemaFile("schema_v33"), 33),
+    setupVersion(readSchemaFile("schema_v34"), 34),
+    setupVersion(readSchemaFile("schema_v35"), 35)
+  )
+
+  private val setupShortCutFunction: Seq[DbTransaction => Future[DbTransaction]] = Seq(
     setupVersion(readSchemaFile("merged_schema_until_v35"), 35)
   )
 

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -127,41 +127,7 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
   }
 
   private val setupFunctions: Seq[DbTransaction => Future[DbTransaction]] = Seq(
-    setupVersion(readSchemaFile("schema_v1"), 1),
-    setupVersion(readSchemaFile("schema_v2"), 2),
-    setupVersion(readSchemaFile("schema_v3"), 3),
-    setupVersion(readSchemaFile("schema_v4"), 4),
-    setupVersion(readSchemaFile("schema_v5"), 5),
-    setupVersion(readSchemaFile("schema_v6"), 6),
-    setupVersion(readSchemaFile("schema_v7"), 7),
-    setupVersion(readSchemaFile("schema_v8"), 8),
-    setupVersion(readSchemaFile("schema_v9"), 9),
-    setupVersion(readSchemaFile("schema_v10"), 10),
-    setupVersion(readSchemaFile("schema_v11"), 11),
-    setupVersion(readSchemaFile("schema_v12"), 12),
-    setupVersion(readSchemaFile("schema_v13"), 13),
-    setupVersion(readSchemaFile("schema_v14"), 14),
-    setupVersion(readSchemaFile("schema_v15"), 15),
-    setupVersion(readSchemaFile("schema_v16"), 16),
-    setupVersion(readSchemaFile("schema_v17"), 17),
-    setupVersion(readSchemaFile("schema_v18"), 18),
-    setupVersion(readSchemaFile("schema_v19"), 19),
-    setupVersion(readSchemaFile("schema_v20"), 20),
-    setupVersion(readSchemaFile("schema_v21"), 21),
-    setupVersion(readSchemaFile("schema_v22"), 22),
-    setupVersion(readSchemaFile("schema_v23"), 23),
-    setupVersion(readSchemaFile("schema_v24"), 24),
-    setupVersion(readSchemaFile("schema_v25"), 25),
-    setupVersion(readSchemaFile("schema_v26"), 26),
-    setupVersion(readSchemaFile("schema_v27"), 27),
-    setupVersion(readSchemaFile("schema_v28"), 28),
-    setupVersion(readSchemaFile("schema_v29"), 29),
-    setupVersion(readSchemaFile("schema_v30"), 30),
-    setupVersion(readSchemaFile("schema_v31"), 31),
-    setupVersion(readSchemaFile("schema_v32"), 32),
-    setupVersion(readSchemaFile("schema_v33"), 33),
-    setupVersion(readSchemaFile("schema_v34"), 34),
-    setupVersion(readSchemaFile("schema_v35"), 35)
+    setupVersion(readSchemaFile("merged_schema_until_v35"), 35)
   )
 
   private def readSchemaFile(name: String): String = {

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -10,6 +10,7 @@ import org.vertx.scala.core.json.Json
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.scalatest.Ignore
 
 @RunWith(classOf[VertxUnitRunner])
 class SystemControllerTest extends TableauxTestBase {
@@ -67,31 +68,31 @@ class SystemControllerTest extends TableauxTestBase {
     }
   }
 
-  @Test
-  def retrieveVersions(implicit c: TestContext): Unit = {
-    okTest {
-      val expectedJson = Json.obj(
-        "database" -> Json.obj(
-          "current" -> 35,
-          "specification" -> 35
-        )
-      )
+  // @Test
+  // def retrieveVersions(implicit c: TestContext): Unit = {
+  //   okTest {
+  //     val expectedJson = Json.obj(
+  //       "database" -> Json.obj(
+  //         "current" -> 35,
+  //         "specification" -> 35
+  //       )
+  //     )
 
-      for {
-        _ <- {
-          val nonce = SystemRouter.generateNonce()
-          sendRequest("POST", s"/system/reset?nonce=$nonce")
-        }
-        _ <- {
-          val nonce = SystemRouter.generateNonce()
-          sendRequest("POST", s"/system/resetDemo?nonce=$nonce")
-        }
-        versions <- sendRequest("GET", "/system/versions")
-      } yield {
-        assertJSONEquals(expectedJson, versions.getJsonObject("versions"))
-      }
-    }
-  }
+  //     for {
+  //       _ <- {
+  //         val nonce = SystemRouter.generateNonce()
+  //         sendRequest("POST", s"/system/reset?nonce=$nonce")
+  //       }
+  //       _ <- {
+  //         val nonce = SystemRouter.generateNonce()
+  //         sendRequest("POST", s"/system/resetDemo?nonce=$nonce")
+  //       }
+  //       versions <- sendRequest("GET", "/system/versions")
+  //     } yield {
+  //       assertJSONEquals(expectedJson, versions.getJsonObject("versions"))
+  //     }
+  //   }
+  // }
 
   @Test
   def resetWithInvalidatedNonceAndNoRequestNonce(implicit c: TestContext): Unit = {

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -10,7 +10,6 @@ import org.vertx.scala.core.json.Json
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.scalatest.Ignore
 
 @RunWith(classOf[VertxUnitRunner])
 class SystemControllerTest extends TableauxTestBase {

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -68,31 +68,31 @@ class SystemControllerTest extends TableauxTestBase {
     }
   }
 
-  // @Test
-  // def retrieveVersions(implicit c: TestContext): Unit = {
-  //   okTest {
-  //     val expectedJson = Json.obj(
-  //       "database" -> Json.obj(
-  //         "current" -> 35,
-  //         "specification" -> 35
-  //       )
-  //     )
+  @Test
+  def retrieveVersions(implicit c: TestContext): Unit = {
+    okTest {
+      val expectedJson = Json.obj(
+        "database" -> Json.obj(
+          "current" -> 35,
+          "specification" -> 35
+        )
+      )
 
-  //     for {
-  //       _ <- {
-  //         val nonce = SystemRouter.generateNonce()
-  //         sendRequest("POST", s"/system/reset?nonce=$nonce")
-  //       }
-  //       _ <- {
-  //         val nonce = SystemRouter.generateNonce()
-  //         sendRequest("POST", s"/system/resetDemo?nonce=$nonce")
-  //       }
-  //       versions <- sendRequest("GET", "/system/versions")
-  //     } yield {
-  //       assertJSONEquals(expectedJson, versions.getJsonObject("versions"))
-  //     }
-  //   }
-  // }
+      for {
+        _ <- {
+          val nonce = SystemRouter.generateNonce()
+          sendRequest("POST", s"/system/reset?nonce=$nonce")
+        }
+        _ <- {
+          val nonce = SystemRouter.generateNonce()
+          sendRequest("POST", s"/system/resetDemo?nonce=$nonce")
+        }
+        versions <- sendRequest("GET", "/system/versions")
+      } yield {
+        assertJSONEquals(expectedJson, versions.getJsonObject("versions"))
+      }
+    }
+  }
 
   @Test
   def resetWithInvalidatedNonceAndNoRequestNonce(implicit c: TestContext): Unit = {

--- a/src/test/scala/com/campudus/tableaux/testtools/TableauxTestBase.scala
+++ b/src/test/scala/com/campudus/tableaux/testtools/TableauxTestBase.scala
@@ -116,6 +116,7 @@ trait TableauxTestBase
 
         for {
           _ <- system.uninstall()
+          _ <- system.installShortCutFunction()
           _ <- system.install()
         } yield async.complete()
 


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

Die Überlegung ist die. Anstatt bei jedem einzelnen Test die Skripte aus Schemafile 1-35 laufen zu lassen, soll für die ersten x files (aktuell 35) ein gemergtes Schema file ausgeführt werden, das direkt und ohne Umwege zum Ziel-Schema fürhrt. Dadurch spart man sich in Summe einige requests, weil weniger alter stmts. Und beim Testsetup werden einige Änderungen nicht gemacht, die später teilweise wieder zurückgenommen wurden.

Die Zeit der Testausführung vermindert sich für alle Tests um ca. ~20-30s.
Ich dachte bringen, dass die Änderungen mehr Zeitgewinn bringen, aber immerhin.
Je mehr am Schema geändert wird, desto mehr wird sich das später aber bemerkbar machen. Dann kann man das Schema erneut mergen und wieder eine "Abkürzung" zum Endschema installieren.