### PR TITLE
AC#1102/custom annotations

### DIFF
--- a/role-permissions-example.json
+++ b/role-permissions-example.json
@@ -273,7 +273,11 @@
         "editServiceDisplayProperty",
         "createMedia",
         "editMedia",
-        "deleteMedia"
+        "deleteMedia",
+        "createCellAnnotationConfig",
+        "viewCellAnnotationConfig",
+        "deleteCellAnnotationConfig",
+        "editCellAnnotationConfig"
       ]
     }
   ]

--- a/role-permissions-test.json
+++ b/role-permissions-test.json
@@ -299,6 +299,15 @@
         "editServiceStructureProperty",
         "editServiceDisplayProperty"
       ]
+    },
+    {
+      "type": "grant",
+      "action": [
+        "createCellAnnotationConfig",
+        "viewCellAnnotationConfig",
+        "deleteCellAnnotationConfig",
+        "editCellAnnotationConfig"
+      ]
     }
   ]
 }

--- a/src/main/resources/schema/schema_v38.sql
+++ b/src/main/resources/schema/schema_v38.sql
@@ -11,10 +11,10 @@ CREATE TABLE system_annotations (
   PRIMARY KEY (name)
 );
 
-INSERT INTO system_annotations 
+INSERT INTO system_annotations
   (name, priority, fg_color, bg_color, display_name, is_multilang, is_dashboard, is_custom)
-VALUES 
-  ('important',         1, '#ffffff', '#ff7474', '{"de":"Wichtig","en":"Important"}',                       FALSE, TRUE, FALSE),
-  ('check-me',          2, '#ffffff', '#c274ff', '{"de":"Bitte überprüfen","en":"Please double-check"}',    FALSE, TRUE, FALSE),
-  ('postpone',          3, '#ffffff', '#999999', '{"de":"Später","en":"Later"}',                            FALSE, TRUE, FALSE),
+VALUES
+  ('important',         1, '#ffffff', '#ff7474', '{"de":"Wichtig","en":"Important"}',                       FALSE, TRUE, TRUE),
+  ('check-me',          2, '#ffffff', '#c274ff', '{"de":"Bitte überprüfen","en":"Please double-check"}',    FALSE, TRUE, TRUE),
+  ('postpone',          3, '#ffffff', '#999999', '{"de":"Später","en":"Later"}',                            FALSE, TRUE, TRUE),
   ('needs_translation', 4, '#ffffff', '#ffae74', '{"de":"Übersetzung nötig","en":"Translation necessary"}', TRUE,  TRUE, FALSE);

--- a/src/main/resources/schema/schema_v38.sql
+++ b/src/main/resources/schema/schema_v38.sql
@@ -11,14 +11,10 @@ CREATE TABLE system_annotations (
   PRIMARY KEY (name)
 );
 
-INSERT INTO system_annotations (name, priority, fg_color, bg_color, display_name, is_multilang, is_dashboard, is_custom)
-	VALUES ('important', 1, '#ffffff', '#ff7474', '{"de":"Wichtig","en":"Important"}', FALSE, TRUE, FALSE);
-
-INSERT INTO system_annotations (name, priority, fg_color, bg_color, display_name, is_multilang, is_dashboard, is_custom)
-	VALUES ('check-me', 2, '#ffffff', '#c274ff', '{"de":"Bitte überprüfen","en":"Please double-check"}', FALSE, TRUE, FALSE);
-
-INSERT INTO system_annotations (name, priority, fg_color, bg_color, display_name, is_multilang, is_dashboard, is_custom)
-	VALUES ('postpone', 3, '#ffffff', '#999999', '{"de":"Später","en":"Later"}', FALSE, TRUE, FALSE);
-
-INSERT INTO system_annotations (name, priority, fg_color, bg_color, display_name, is_multilang, is_dashboard, is_custom)
-	VALUES ('needs_translation', 4, '#ffffff', '#ffae74', '{"de":"Übersetzung nötig","en":"Translation necessary"}', TRUE, TRUE, FALSE);
+INSERT INTO system_annotations 
+  (name, priority, fg_color, bg_color, display_name, is_multilang, is_dashboard, is_custom)
+VALUES 
+  ('important',         1, '#ffffff', '#ff7474', '{"de":"Wichtig","en":"Important"}',                       FALSE, TRUE, FALSE),
+  ('check-me',          2, '#ffffff', '#c274ff', '{"de":"Bitte überprüfen","en":"Please double-check"}',    FALSE, TRUE, FALSE),
+  ('postpone',          3, '#ffffff', '#999999', '{"de":"Später","en":"Later"}',                            FALSE, TRUE, FALSE),
+  ('needs_translation', 4, '#ffffff', '#ffae74', '{"de":"Übersetzung nötig","en":"Translation necessary"}', TRUE,  TRUE, FALSE);

--- a/src/main/resources/schema/schema_v38.sql
+++ b/src/main/resources/schema/schema_v38.sql
@@ -23,7 +23,7 @@ CREATE OR REPLACE FUNCTION add_annotation_name_column(tableid BIGINT)
   RETURNS TEXT AS $$
 BEGIN
   EXECUTE 'ALTER TABLE user_table_annotations_' || tableid || ' ADD COLUMN annotation_name TEXT NULL';
-  EXECUTE 'ALTER TABLE user_table_annotations_' || tableid || ' ADD FOREIGN KEY (annotation_name) REFERENCES system_annotations (name)';
+  EXECUTE 'ALTER TABLE user_table_annotations_' || tableid || ' ADD FOREIGN KEY (annotation_name) REFERENCES system_annotations (name) ON DELETE CASCADE ON UPDATE CASCADE';
   EXECUTE 'UPDATE user_table_annotations_' || tableid || ' SET value = NULL, annotation_name = subquery.value FROM (SELECT uuid, type, value FROM user_table_annotations_' || tableid || ') AS subquery WHERE user_table_annotations_' || tableid || '.uuid = subquery.uuid  AND user_table_annotations_' || tableid || '.type = ''flag''';
   RETURN 'user_table_annotations_' || tableid :: TEXT;
 END

--- a/src/main/resources/schema/schema_v38.sql
+++ b/src/main/resources/schema/schema_v38.sql
@@ -24,7 +24,8 @@ CREATE OR REPLACE FUNCTION add_annotation_name_column(tableid BIGINT)
 BEGIN
   EXECUTE 'ALTER TABLE user_table_annotations_' || tableid || ' ADD COLUMN annotation_name TEXT NULL';
   EXECUTE 'ALTER TABLE user_table_annotations_' || tableid || ' ADD FOREIGN KEY (annotation_name) REFERENCES system_annotations (name) ON DELETE CASCADE ON UPDATE CASCADE';
-  EXECUTE 'UPDATE user_table_annotations_' || tableid || ' SET value = NULL, annotation_name = subquery.value FROM (SELECT uuid, type, value FROM user_table_annotations_' || tableid || ') AS subquery WHERE user_table_annotations_' || tableid || '.uuid = subquery.uuid  AND user_table_annotations_' || tableid || '.type = ''flag''';
+  EXECUTE 'UPDATE user_table_annotations_' || tableid || ' SET annotation_name = value WHERE type = ''flag''';
+  EXECUTE 'UPDATE user_table_annotations_' || tableid || ' SET value = NULL WHERE type = ''flag''';
   RETURN 'user_table_annotations_' || tableid :: TEXT;
 END
 $$ LANGUAGE plpgsql;

--- a/src/main/resources/schema/schema_v38.sql
+++ b/src/main/resources/schema/schema_v38.sql
@@ -1,0 +1,24 @@
+CREATE TABLE system_annotations (
+  name          VARCHAR(50) NOT NULL,
+  priority      SERIAL,
+  fg_color      VARCHAR(50) NULL,
+  bg_color      VARCHAR(50) NULL,
+  display_name  JSON,
+  is_multilang  BOOLEAN NOT NULL DEFAULT FALSE,
+  is_dashboard  BOOLEAN NOT NULL DEFAULT TRUE,
+  is_custom     BOOLEAN NOT NULL DEFAULT TRUE,
+
+  PRIMARY KEY (name)
+);
+
+INSERT INTO system_annotations (name, priority, fg_color, bg_color, display_name, is_multilang, is_dashboard, is_custom)
+	VALUES ('important', 1, '#ffffff', '#ff7474', '{"de":"Wichtig","en":"Important"}', FALSE, TRUE, FALSE);
+
+INSERT INTO system_annotations (name, priority, fg_color, bg_color, display_name, is_multilang, is_dashboard, is_custom)
+	VALUES ('check-me', 2, '#ffffff', '#c274ff', '{"de":"Bitte überprüfen","en":"Please double-check"}', FALSE, TRUE, FALSE);
+
+INSERT INTO system_annotations (name, priority, fg_color, bg_color, display_name, is_multilang, is_dashboard, is_custom)
+	VALUES ('postpone', 3, '#ffffff', '#999999', '{"de":"Später","en":"Later"}', FALSE, TRUE, FALSE);
+
+INSERT INTO system_annotations (name, priority, fg_color, bg_color, display_name, is_multilang, is_dashboard, is_custom)
+	VALUES ('needs_translation', 4, '#ffffff', '#ffae74', '{"de":"Übersetzung nötig","en":"Translation necessary"}', TRUE, TRUE, FALSE);

--- a/src/main/resources/swagger.json
+++ b/src/main/resources/swagger.json
@@ -610,7 +610,7 @@
         "tags": [
           "system"
         ],
-        "operationId": "get-all-annotations",
+        "operationId": "get-all-annotation-configs",
         "consumes": [],
         "produces": [
           "application/json"
@@ -628,6 +628,32 @@
             "schema": {
               "$ref": "#/responses/unknown-error"
             }
+          }
+        }
+      }
+    },
+    "/system/annotations/{annotationName}": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/annotationName"
+        }
+      ],
+      "get": {
+        "summary": "Get annotation config",
+        "description": "Returns the config of an annotation.",
+        "tags": [
+          "system"
+        ],
+        "operationId": "get-annotation-config",
+        "responses": {
+          "200": {
+            "description": "Config of the annotation",
+            "schema": {
+              "$ref": "#/definitions/CellAnnotationConfig"
+            }
+          },
+          "404": {
+            "$ref": "#/responses/not-found-in-database"
           }
         }
       }
@@ -4311,6 +4337,14 @@
       "in": "query",
       "type": "boolean",
       "required": false
+    },
+    "annotationName": {
+      "name": "annotationName",
+      "description": "The name of the annotation",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "example": "postpone"
     }
   },
   "responses": {

--- a/src/main/resources/swagger.json
+++ b/src/main/resources/swagger.json
@@ -656,6 +656,22 @@
             "$ref": "#/responses/not-found-in-database"
           }
         }
+      },
+      "delete": {
+        "summary": "Delete an annotation config",
+        "description": "Deletes the config of an annotation.",
+        "tags": [
+          "system"
+        ],
+        "operationId": "delete-annotation-config",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/ok-empty-body"
+          },
+          "404": {
+            "$ref": "#/responses/not-found-in-database"
+          }
+        }
       }
     },
     "/system/update": {

--- a/src/main/resources/swagger.json
+++ b/src/main/resources/swagger.json
@@ -603,6 +603,35 @@
         }
       }
     },
+    "/system/annotations": {
+      "get": {
+        "summary": "Get all annotation configs",
+        "description": "Returns an array containing all available annotation configs.",
+        "tags": [
+          "system"
+        ],
+        "operationId": "get-all-annotations",
+        "consumes": [],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "The annotations",
+            "schema": {
+              "$ref": "#/definitions/Response: Annotation Configs"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/responses/unknown-error"
+            }
+          }
+        }
+      }
+    },
     "/system/update": {
       "post": {
         "summary": "Update system tables",
@@ -2219,6 +2248,63 @@
         }
       }
     },
+    "CellAnnotationConfig": {
+      "type": "object",
+      "required": [
+        "name",
+        "priority",
+        "fgColor",
+        "bgColor",
+        "displayName",
+        "isMultilang",
+        "isDashboard"
+      ],
+      "properties": {
+        "name": {
+          "description": "name of the annotation",
+          "type": "string",
+          "example": "important"
+        },
+        "priority": {
+          "description": "priority of the annotation",
+          "type": "number",
+          "example": 1
+        },
+        "fgColor": {
+          "description": "foreground color of the annotation",
+          "type": "string",
+          "example": "#ffffff"
+        },
+        "bgColor": {
+          "description": "background color of the annotation",
+          "type": "string",
+          "example": "#ff7474"
+        },
+        "displayName": {
+          "description": "display name of the annotation as multilang obj",
+          "type": "object",
+          "example": {
+            "de": "Wichtig",
+            "en": "Important"
+          }
+        },
+        "isMultilang": {
+          "description": "multilang flag for the annotation",
+          "type": "boolean",
+          "example": false
+        },
+        "isDashboard": {
+          "description": "dashboard flag for the annotation",
+          "type": "boolean",
+          "example": true
+        },
+        "isCustom": {
+          "description": "custom flag for the annotation",
+          "type": "boolean",
+          "example": true
+        }
+      }
+    },
     "Pagination": {
       "type": "object",
       "required": [
@@ -2473,6 +2559,25 @@
       },
       "required": [
         "services"
+      ]
+    },
+    "Response: Annotation Configs": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Property:Status"
+        }
+      ],
+      "properties": {
+        "annotations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/CellAnnotationConfig"
+          }
+        }
+      },
+      "required": [
+        "annotations"
       ]
     },
     "Response:Cell": {

--- a/src/main/resources/swagger.json
+++ b/src/main/resources/swagger.json
@@ -657,6 +657,35 @@
           }
         }
       },
+      "patch": {
+        "summary": "Update annotation config",
+        "description": "Updates an annotation config.",
+        "tags": [
+          "system"
+        ],
+        "operationId": "update-annotation-config",
+        "parameters": [
+          {
+            "name": "annotation config",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CellAnnotationConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Config of the annotation",
+            "schema": {
+              "$ref": "#/definitions/CellAnnotationConfig"
+            }
+          },
+          "404": {
+            "$ref": "#/responses/not-found-in-database"
+          }
+        }
+      },
       "delete": {
         "summary": "Delete an annotation config",
         "description": "Deletes the config of an annotation.",

--- a/src/main/resources/swagger.json
+++ b/src/main/resources/swagger.json
@@ -630,6 +630,38 @@
             }
           }
         }
+      },
+      "post": {
+        "summary": "Create a new annotation config",
+        "description": "Creates the annotation config.",
+        "tags": [
+          "system"
+        ],
+        "operationId": "create-new-annotation-config",
+        "parameters": [
+          {
+            "name": "annotation config",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Request: Create annotation config"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The new annotation config",
+            "schema": {
+              "$ref": "#/definitions/CellAnnotationConfig"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/responses/unknown-error"
+            }
+          }
+        }
       }
     },
     "/system/annotations/{annotationName}": {
@@ -3266,6 +3298,56 @@
           "type": "global"
         }
       }
+    },
+    "Request: Create annotation config": {
+      "type": "object",
+      "required": [
+        "name",
+        "fgColor",
+        "bgColor",
+        "displayName"
+      ],
+      "properties": {
+        "name": {
+          "description": "name of the annotation",
+          "type": "string",
+          "example": "important"
+        },
+        "priority": {
+          "description": "priority of the annotation",
+          "type": "number",
+          "example": 1
+        },
+        "fgColor": {
+          "description": "foreground color of the annotation",
+          "type": "string",
+          "example": "#ffffff"
+        },
+        "bgColor": {
+          "description": "background color of the annotation",
+          "type": "string",
+          "example": "#ff7474"
+        },
+        "displayName": {
+          "description": "display name of the annotation as multilang obj",
+          "type": "object",
+          "example": {
+            "de": "Wichtig",
+            "en": "Important"
+          }
+        },
+        "isMultilang": {
+          "description": "multilang flag for the annotation",
+          "type": "boolean",
+          "example": false
+        },
+        "isDashboard": {
+          "description": "dashboard flag for the annotation",
+          "type": "boolean",
+          "example": true
+        }
+      },
+      "description": "Creates a new annotation config."
     },
     "Response: Complete table": {
       "type": "object",

--- a/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
@@ -378,4 +378,33 @@ class SystemController(
       _ <- cellAnnotationConfigModel.delete(annotationName)
     } yield EmptyObject()
   }
+
+  def updateCellAnnotationConfig(
+      name: String,
+      priority: Option[Int],
+      fgColor: Option[String],
+      bgColor: Option[String],
+      displayName: Option[MultiLanguageValue[String]],
+      isMultilang: Option[Boolean],
+      isDashboard: Option[Boolean]
+  )(implicit user: TableauxUser): Future[DomainObject] = {
+
+    checkArguments(
+      notNull(name, "name"),
+      isDefined(
+        Seq(priority, fgColor, bgColor, displayName, isMultilang, isDashboard),
+        "priority, fgColor, bgColor, displayName, isMultilang, isDashboard"
+      )
+    )
+
+    logger.info(
+      s"updateCellAnnotationConfig $name $priority $fgColor $bgColor $displayName $isMultilang $isDashboard"
+    )
+
+    for {
+      _ <- roleModel.checkAuthorization(EditCellAnnotationConfig)
+      _ <- cellAnnotationConfigModel.update(name, priority, fgColor, bgColor, displayName, isMultilang, isDashboard)
+      annotationConfig <- retrieveCellAnnotationConfig(name)
+    } yield annotationConfig
+  }
 }

--- a/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
@@ -345,4 +345,13 @@ class SystemController(
       PlainDomainObject(json)
     }
   }
+
+  def retrieveAnnotation(annotationName: String)(implicit user: TableauxUser): Future[CellAnnotationConfig] = {
+    logger.info(s"retrieveAnnotation $annotationName")
+
+    for {
+      _ <- roleModel.checkAuthorization(ViewCellAnnotationConfig)
+      annotation <- annotationModel.retrieve(annotationName)
+    } yield annotation
+  }
 }

--- a/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
@@ -422,7 +422,7 @@ class SystemController(
       notNull(name, "name"),
       notNull(fgColor, "fgColor"),
       notNull(bgColor, "bgColor"),
-      notNull(displayName, "displayName"),
+      notNull(displayName, "displayName")
     )
 
     logger.info(

--- a/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
@@ -407,4 +407,32 @@ class SystemController(
       annotationConfig <- retrieveCellAnnotationConfig(name)
     } yield annotationConfig
   }
+
+  def createCellAnnotationConfig(
+      name: String,
+      priority: Option[Int],
+      fgColor: String,
+      bgColor: String,
+      displayName: MultiLanguageValue[String],
+      isMultilang: Option[Boolean],
+      isDashboard: Option[Boolean]
+  )(implicit user: TableauxUser): Future[DomainObject] = {
+
+    checkArguments(
+      notNull(name, "name"),
+      notNull(fgColor, "fgColor"),
+      notNull(bgColor, "bgColor"),
+      notNull(displayName, "displayName"),
+    )
+
+    logger.info(
+      s"createCellAnnotationConfig $name $priority $fgColor $bgColor $displayName $isMultilang $isDashboard"
+    )
+
+    for {
+      _ <- roleModel.checkAuthorization(CreateCellAnnotationConfig)
+      _ <- cellAnnotationConfigModel.create(name, priority, fgColor, bgColor, displayName, isMultilang, isDashboard)
+      annotationConfig <- retrieveCellAnnotationConfig(name)
+    } yield annotationConfig
+  }
 }

--- a/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
@@ -369,4 +369,13 @@ class SystemController(
       annotation <- cellAnnotationConfigModel.retrieve(annotationName)
     } yield annotation
   }
+
+  def deleteCellAnnotationConfig(annotationName: String)(implicit user: TableauxUser): Future[DomainObject] = {
+    logger.info(s"deleteCellAnnotationConfig $annotationName")
+
+    for {
+      _ <- roleModel.checkAuthorization(DeleteCellAnnotationConfig)
+      _ <- cellAnnotationConfigModel.delete(annotationName)
+    } yield EmptyObject()
+  }
 }

--- a/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
@@ -4,7 +4,13 @@ import com.campudus.tableaux.ArgumentChecker._
 import com.campudus.tableaux.TableauxConfig
 import com.campudus.tableaux.cache.CacheClient
 import com.campudus.tableaux.database.domain._
-import com.campudus.tableaux.database.model.{ServiceModel, StructureModel, SystemModel, TableauxModel, AnnotationModel}
+import com.campudus.tableaux.database.model.{
+  CellAnnotationConfigModel,
+  ServiceModel,
+  StructureModel,
+  SystemModel,
+  TableauxModel
+}
 import com.campudus.tableaux.database.model.ServiceModel.ServiceId
 import com.campudus.tableaux.database.model.TableauxModel.{ColumnId, TableId}
 import com.campudus.tableaux.helper.JsonUtils
@@ -27,9 +33,17 @@ object SystemController {
       structureModel: StructureModel,
       serviceModel: ServiceModel,
       roleModel: RoleModel,
-      annotationModel: AnnotationModel,
+      cellAnnotationConfigModel: CellAnnotationConfigModel
   ): SystemController = {
-    new SystemController(config, repository, tableauxModel, structureModel, serviceModel, roleModel, annotationModel)
+    new SystemController(
+      config,
+      repository,
+      tableauxModel,
+      structureModel,
+      serviceModel,
+      roleModel,
+      cellAnnotationConfigModel
+    )
   }
 }
 
@@ -42,7 +56,7 @@ class SystemController(
     protected val structureModel: StructureModel,
     protected val serviceModel: ServiceModel,
     implicit protected val roleModel: RoleModel,
-    protected val annotationModel: AnnotationModel,
+    protected val cellAnnotationConfigModel: CellAnnotationConfigModel
 ) extends Controller[SystemModel] {
 
   def retrieveSchemaVersion(): Future[SchemaVersion] = {
@@ -335,10 +349,10 @@ class SystemController(
     } yield EmptyObject()
   }
 
-  def retrieveAnnotations()(implicit user: TableauxUser): Future[DomainObject] = {
-    logger.info(s"retrieveAnnotations")
+  def retrieveCellAnnotationConfigs()(implicit user: TableauxUser): Future[DomainObject] = {
+    logger.info(s"retrieveCellAnnotationConfigs")
     for {
-      annotations <- annotationModel.retrieveAll()
+      annotations <- cellAnnotationConfigModel.retrieveAll()
     } yield {
       val json = Json.obj("annotations" -> annotations.map(_.getJson))
 
@@ -346,12 +360,13 @@ class SystemController(
     }
   }
 
-  def retrieveAnnotation(annotationName: String)(implicit user: TableauxUser): Future[CellAnnotationConfig] = {
-    logger.info(s"retrieveAnnotation $annotationName")
+  def retrieveCellAnnotationConfig(annotationName: String)(implicit
+  user: TableauxUser): Future[CellAnnotationConfig] = {
+    logger.info(s"retrieveCellAnnotationConfig $annotationName")
 
     for {
       _ <- roleModel.checkAuthorization(ViewCellAnnotationConfig)
-      annotation <- annotationModel.retrieve(annotationName)
+      annotation <- cellAnnotationConfigModel.retrieve(annotationName)
     } yield annotation
   }
 }

--- a/src/main/scala/com/campudus/tableaux/database/domain/annotation.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/annotation.scala
@@ -246,3 +246,26 @@ case object RowAnnotationTypeFinal extends RowAnnotationType {
 case object RowAnnotationTypeArchived extends RowAnnotationType {
   override val typeName = RowAnnotationType.Archived
 }
+
+case class CellAnnotationConfig(
+    name: String,
+    priority: Integer,
+    fgColor: String,
+    bgColor: String,
+    displayName: MultiLanguageValue[String],
+    isMultilang: Boolean,
+    isDashboard: Boolean,
+    isCustom: Boolean
+) extends DomainObject {
+
+  override def getJson: JsonObject = Json.obj(
+    "name" -> name,
+    "priority" -> priority,
+    "fgColor" -> fgColor,
+    "bgColor" -> bgColor,
+    "displayName" -> displayName.getJson,
+    "isMultilang" -> isMultilang,
+    "isDashboard" -> isDashboard,
+    "isCustom" -> isCustom
+  )
+}

--- a/src/main/scala/com/campudus/tableaux/database/domain/annotation.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/annotation.scala
@@ -249,7 +249,7 @@ case object RowAnnotationTypeArchived extends RowAnnotationType {
 
 case class CellAnnotationConfig(
     name: String,
-    priority: Integer,
+    priority: Int,
     fgColor: String,
     bgColor: String,
     displayName: MultiLanguageValue[String],

--- a/src/main/scala/com/campudus/tableaux/database/model/AnnotationModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/AnnotationModel.scala
@@ -1,0 +1,173 @@
+package com.campudus.tableaux.database.model
+
+import com.campudus.tableaux.ShouldBeUniqueException
+import com.campudus.tableaux.database._
+import com.campudus.tableaux.database.domain._
+import com.campudus.tableaux.helper.JsonUtils
+import com.campudus.tableaux.helper.ResultChecker._
+import com.campudus.tableaux.router.auth.permission.{RoleModel, TableauxUser}
+
+import io.vertx.scala.ext.web.RoutingContext
+import org.vertx.scala.core.json.{Json, JsonArray, JsonObject}
+
+import scala.concurrent.Future
+
+object AnnotationModel {
+
+  def apply(connection: DatabaseConnection)(
+      implicit roleModel: RoleModel
+  ): AnnotationModel = {
+    new AnnotationModel(connection)
+  }
+}
+
+class AnnotationModel(override protected[this] val connection: DatabaseConnection)(
+    implicit roleModel: RoleModel
+) extends DatabaseQuery {
+  val table: String = "system_annotations"
+
+  def update(
+      name: String,
+      priority: Option[Integer],
+      fgColor: Option[String],
+      bgColor: Option[String],
+      displayName: Option[MultiLanguageValue[String]],
+      isMultilang: Option[Boolean],
+      isDashboard: Option[Boolean]
+  )(implicit user: TableauxUser): Future[CellAnnotationConfig] = {
+
+    val updateParamOpts = Map(
+      "priority" -> priority,
+      "fg_color" -> fgColor,
+      "bg_color" -> bgColor,
+      "display_name" -> displayName,
+      "is_multilang" -> isMultilang,
+      "is_dashboard" -> isDashboard
+    )
+
+    val paramsToUpdate = updateParamOpts
+      .filter({ case (_, v) => v.isDefined })
+      .map({ case (k, v) => (k, v.get) })
+
+    val columnString2valueString: Map[String, String] = paramsToUpdate.map({
+      case (columnName, value) =>
+        val columnString = s"$columnName = ?"
+
+        val valueString = value match {
+          case m: MultiLanguageValue[_] => m.getJson.toString
+          case a => a.toString
+        }
+
+        columnString -> valueString
+    })
+
+    val columnsString = columnString2valueString.keys.mkString(", ")
+    val update = s"UPDATE $table SET $columnsString WHERE name = ?"
+
+    val binds = Json.arr(columnString2valueString.values.toSeq: _*).add(name)
+
+    for {
+      _ <- connection.query(update, binds)
+      annotation <- retrieve(name)
+    } yield annotation
+  }
+
+  private def selectStatement(condition: Option[String]): String = {
+
+    val where = condition.map(cond => s"WHERE $cond").getOrElse("")
+
+    s"""SELECT
+       |  name,
+       |  priority,
+       |  fg_color,
+       |  bg_color,
+       |  display_name,
+       |  is_multilang,
+       |  is_dashboard,
+       |  is_custom
+       |FROM $table $where
+       |ORDER BY priority""".stripMargin
+  }
+
+  def retrieve(name: String)(implicit user: TableauxUser): Future[CellAnnotationConfig] = {
+    for {
+      result <- connection.query(selectStatement(Some("name = ?")), Json.arr(name))
+      resultArr <- Future(selectNotNull(result))
+    } yield {
+      convertJsonArrayToCellAnnotationConfig(resultArr.head)
+    }
+  }
+
+  def delete(name: String): Future[Unit] = {
+    val delete = s"DELETE FROM $table WHERE name = ?"
+
+    for {
+      result <- connection.query(delete, Json.arr(name))
+      _ <- Future(deleteNotNull(result))
+    } yield ()
+  }
+
+  def create(
+      name: String,
+      priority: Option[Integer],
+      fgColor: String,
+      bgColor: String,
+      displayName: MultiLanguageValue[String],
+      isMultilang: Boolean,
+      isDashboard: Boolean
+  )(implicit user: TableauxUser): Future[String] = {
+
+    val insert = s"""INSERT INTO $table (
+                    |  name,
+                    |  priority,
+                    |  fg_color,
+                    |  bg_color,
+                    |  display_name,
+                    |  is_multilang,
+                    |  is_dashboard)
+                    |VALUES
+                    |  (?, ?, ?, ?, ?, ?, ?) RETURNING name""".stripMargin
+
+    for {
+      result <- connection.query(
+        insert,
+        Json
+          .arr(
+            name,
+            priority.orNull,
+            fgColor,
+            bgColor,
+            displayName.getJson.toString,
+            isMultilang,
+            isDashboard
+          )
+      )
+
+      configName = insertNotNull(result).head.get[String](0)
+    } yield configName
+
+  }
+
+  def retrieveAll()(implicit user: TableauxUser): Future[Seq[CellAnnotationConfig]] = {
+    for {
+      result <- connection.query(selectStatement(None))
+      resultArr <- Future(resultObjectToJsonArray(result))
+    } yield {
+      resultArr.map(convertJsonArrayToCellAnnotationConfig)
+    }
+  }
+
+  private def convertJsonArrayToCellAnnotationConfig(arr: JsonArray)(implicit
+  user: TableauxUser): CellAnnotationConfig = {
+    CellAnnotationConfig(
+      arr.get[String](0), // name
+      arr.get[Integer](1), // priority
+      arr.get[String](2), // fgColor
+      arr.get[String](3), // bgColor
+      MultiLanguageValue.fromString(arr.get[String](4)), // displayName
+      arr.get[Boolean](5), // isMultilang
+      arr.get[Boolean](6), // isDashboard
+      arr.get[Boolean](7) // isCustom
+    )
+  }
+}

--- a/src/main/scala/com/campudus/tableaux/database/model/CellAnnotationConfigModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/CellAnnotationConfigModel.scala
@@ -28,7 +28,7 @@ class CellAnnotationConfigModel(override protected[this] val connection: Databas
 
   def update(
       name: String,
-      priority: Option[Integer],
+      priority: Option[Int],
       fgColor: Option[String],
       bgColor: Option[String],
       displayName: Option[MultiLanguageValue[String]],
@@ -109,7 +109,7 @@ class CellAnnotationConfigModel(override protected[this] val connection: Databas
 
   def create(
       name: String,
-      priority: Option[Integer],
+      priority: Option[Int],
       fgColor: String,
       bgColor: String,
       displayName: MultiLanguageValue[String],
@@ -161,7 +161,7 @@ class CellAnnotationConfigModel(override protected[this] val connection: Databas
   user: TableauxUser): CellAnnotationConfig = {
     CellAnnotationConfig(
       arr.get[String](0), // name
-      arr.get[Integer](1), // priority
+      arr.get[Int](1), // priority
       arr.get[String](2), // fgColor
       arr.get[String](3), // bgColor
       MultiLanguageValue.fromString(arr.get[String](4)), // displayName

--- a/src/main/scala/com/campudus/tableaux/database/model/CellAnnotationConfigModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/CellAnnotationConfigModel.scala
@@ -135,7 +135,7 @@ class CellAnnotationConfigModel(override protected[this] val connection: Databas
         Json
           .arr(
             name,
-            priority.getOrElse(null),
+            priority.orNull,
             fgColor,
             bgColor,
             displayName.getJson.toString,

--- a/src/main/scala/com/campudus/tableaux/database/model/CellAnnotationConfigModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/CellAnnotationConfigModel.scala
@@ -12,16 +12,16 @@ import org.vertx.scala.core.json.{Json, JsonArray, JsonObject}
 
 import scala.concurrent.Future
 
-object AnnotationModel {
+object CellAnnotationConfigModel {
 
   def apply(connection: DatabaseConnection)(
       implicit roleModel: RoleModel
-  ): AnnotationModel = {
-    new AnnotationModel(connection)
+  ): CellAnnotationConfigModel = {
+    new CellAnnotationConfigModel(connection)
   }
 }
 
-class AnnotationModel(override protected[this] val connection: DatabaseConnection)(
+class CellAnnotationConfigModel(override protected[this] val connection: DatabaseConnection)(
     implicit roleModel: RoleModel
 ) extends DatabaseQuery {
   val table: String = "system_annotations"

--- a/src/main/scala/com/campudus/tableaux/database/model/CellAnnotationConfigModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/CellAnnotationConfigModel.scala
@@ -126,7 +126,7 @@ class CellAnnotationConfigModel(override protected[this] val connection: Databas
                     |  is_multilang,
                     |  is_dashboard)
                     |VALUES
-                    |  (?, COALESCE(?, (SELECT MAX(priority) FROM $table), 0) + 1, ?, ?, ?, ?, ?) RETURNING name""".stripMargin
+                    |  (?, COALESCE(?, (SELECT MAX(priority) FROM $table) + 1, 1), ?, ?, ?, ?, ?) RETURNING name""".stripMargin
 
     for {
       _ <- checkUniqueName(name)

--- a/src/main/scala/com/campudus/tableaux/database/model/CellAnnotationConfigModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/CellAnnotationConfigModel.scala
@@ -1,6 +1,6 @@
 package com.campudus.tableaux.database.model
 
-import com.campudus.tableaux.{ShouldBeUniqueException, ForbiddenException}
+import com.campudus.tableaux.{ForbiddenException, ShouldBeUniqueException}
 import com.campudus.tableaux.database._
 import com.campudus.tableaux.database.domain._
 import com.campudus.tableaux.helper.JsonUtils

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -186,7 +186,8 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
     setupVersion(readSchemaFile("schema_v34"), 34),
     setupVersion(readSchemaFile("schema_v35"), 35),
     setupVersion(readSchemaFile("schema_v36"), 36),
-    setupVersion(readSchemaFile("schema_v37"), 37)
+    setupVersion(readSchemaFile("schema_v37"), 37),
+    setupVersion(readSchemaFile("schema_v38"), 38)
   )
 
   private val setupShortCutFunction: Seq[DbTransaction => Future[DbTransaction]] = Seq(

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
@@ -153,10 +153,12 @@ class TableModel(val connection: DatabaseConnection)(
                            |   langtags TEXT[] NOT NULL DEFAULT '{}'::text[],
                            |   type VARCHAR(255) NOT NULL,
                            |   value TEXT NULL,
+                           |   annotation_name TEXT NULL,
                            |   created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT now(),
                            |
                            |   PRIMARY KEY (row_id, column_id, uuid),
-                           |   FOREIGN KEY (row_id) REFERENCES user_table_$id (id) ON DELETE CASCADE
+                           |   FOREIGN KEY (row_id) REFERENCES user_table_$id (id) ON DELETE CASCADE,
+                           |   FOREIGN KEY (annotation_name) REFERENCES system_annotations (name) ON DELETE CASCADE
                            | )
          """.stripMargin)
     } yield t

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
@@ -158,7 +158,7 @@ class TableModel(val connection: DatabaseConnection)(
                            |
                            |   PRIMARY KEY (row_id, column_id, uuid),
                            |   FOREIGN KEY (row_id) REFERENCES user_table_$id (id) ON DELETE CASCADE,
-                           |   FOREIGN KEY (annotation_name) REFERENCES system_annotations (name) ON DELETE CASCADE
+                           |   FOREIGN KEY (annotation_name) REFERENCES system_annotations (name) ON DELETE CASCADE ON UPDATE CASCADE
                            | )
          """.stripMargin)
     } yield t

--- a/src/main/scala/com/campudus/tableaux/database/model/tableaux/RowModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/tableaux/RowModel.scala
@@ -732,7 +732,7 @@ class UpdateRowModel(val connection: DatabaseConnection) extends DatabaseQuery w
          |    row_id = ? AND
          |    column_id = ? AND
          |    type = ? AND
-         |		annotation_name = ?
+         |    annotation_name = ?
          |) AS subquery
          |WHERE
          |  user_table_annotations_$tableId.row_id = subquery.row_id AND

--- a/src/main/scala/com/campudus/tableaux/database/model/tableaux/RowModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/tableaux/RowModel.scala
@@ -679,11 +679,20 @@ class UpdateRowModel(val connection: DatabaseConnection) extends DatabaseQuery w
     val tableId = column.table.id
     val newUuid = UUID.randomUUID()
 
+    val textValue = annotationType match {
+      case FlagAnnotationType => None
+      case _ => Some(value)
+    }
+    val annotationName = annotationType match {
+      case FlagAnnotationType => Some(value)
+      case _ => None
+    }
+
     val insertStatement =
       s"""
          |INSERT INTO
-         |  user_table_annotations_$tableId(row_id, column_id, uuid, langtags, type, value)
-         |VALUES (?, ?, ?, ?::text[], ?, ?)
+         |  user_table_annotations_$tableId(row_id, column_id, uuid, langtags, type, value, annotation_name)
+         |VALUES (?, ?, ?, ?::text[], ?, ?, ?)
          |RETURNING ${parseDateTimeSql("created_at")}""".stripMargin
 
     val insertBinds = Json.arr(
@@ -692,7 +701,8 @@ class UpdateRowModel(val connection: DatabaseConnection) extends DatabaseQuery w
       newUuid.toString,
       langtags.mkString("{", ",", "}"),
       annotationType.toString,
-      value
+      textValue.orNull,
+      annotationName.orNull
     )
 
     // https://github.com/vert-x3/vertx-mysql-postgresql-client/pull/75
@@ -710,6 +720,7 @@ class UpdateRowModel(val connection: DatabaseConnection) extends DatabaseQuery w
          |    uuid,
          |    type,
          |    value,
+         |    annotation_name,
          |    (
          |      SELECT array(
          |        SELECT DISTINCT unnest(array_cat(langtags, ?::text[])) AS langtag ORDER BY langtag
@@ -721,12 +732,12 @@ class UpdateRowModel(val connection: DatabaseConnection) extends DatabaseQuery w
          |    row_id = ? AND
          |    column_id = ? AND
          |    type = ? AND
-         |    value = ?
+         |		annotation_name = ?
          |) AS subquery
          |WHERE
          |  user_table_annotations_$tableId.row_id = subquery.row_id AND
          |  user_table_annotations_$tableId.column_id = subquery.column_id AND
-         |  user_table_annotations_$tableId.value = subquery.value AND
+         |  user_table_annotations_$tableId.annotation_name = subquery.annotation_name AND
          |  user_table_annotations_$tableId.type = 'flag'
          |RETURNING
          |  user_table_annotations_$tableId.uuid,
@@ -738,7 +749,7 @@ class UpdateRowModel(val connection: DatabaseConnection) extends DatabaseQuery w
       rowId,
       column.id,
       annotationType.toString,
-      value
+      annotationName.orNull
     )
 
     connection.transactional(t => {
@@ -973,7 +984,7 @@ class RetrieveRowModel(val connection: DatabaseConnection)(
              |ua.uuid,
              |array_to_json(ua.langtags::text[]) AS langtags,
              |ua.type,
-             |ua.value,
+             |CASE WHEN ua.type = 'flag' THEN annotation_name ELSE value END,
              |${parseDateTimeSql("ua.created_at")} AS created_at
              |FROM user_table_$id ut JOIN user_table_annotations_$id ua ON (ut.id = ua.row_id)""".stripMargin
       })
@@ -1056,21 +1067,21 @@ class RetrieveRowModel(val connection: DatabaseConnection)(
 
     /**
       * If type is not flag we ignore the value. Other types (info, warning, error) are comment annotations. Their
-      * values are always different. The value of flag annotations is important because it describes what sort of flag
-      * annotation it is (needs_translation, important, check-me, later).
+      * values are always different. The annotation_name of flag annotations is important because it describes what sort
+      * of flag annotation it is (needs_translation, important, check-me, later).
       */
     val query = tables
       .map({ tableId =>
         s"""|SELECT
             |$tableId::bigint as table_id,
             |ua.type,
-            |CASE WHEN type = 'flag' THEN value END AS type_value,
+            |CASE WHEN type = 'flag' THEN annotation_name END AS type_value,
             |sub.langtag AS langtag,
             |COUNT(*),
             |${parseDateTimeSql("MAX(ua.created_at)")} AS last_created_at
             |FROM user_table_annotations_$tableId ua
             |LEFT JOIN LATERAL UNNEST(ua.langtags) AS sub(langtag) ON ua.langtags <> '{}'
-            |WHERE NOT (type = 'flag' AND value = 'needs_translation' AND (langtags = '{}' OR langtags IS NULL))
+            |WHERE NOT (type = 'flag' AND annotation_name = 'needs_translation' AND (langtags = '{}' OR langtags IS NULL))
             |GROUP BY type, type_value, langtag""".stripMargin
       })
       .mkString("", " UNION ALL ", " ORDER BY table_id, type, type_value, last_created_at DESC")
@@ -1473,10 +1484,10 @@ class RetrieveRowModel(val connection: DatabaseConnection)(
         |    'uuid', uuid,
         |    'langtags', langtags::text[],
         |    'type', type,
-        |    'value', value,
+        |    'value', CASE WHEN type = 'flag' THEN annotation_name ELSE value END,
         |    'createdAt', ${parseDateTimeSql("created_at")}
         | )
-        |) FROM (SELECT column_id, uuid, langtags, type, value, created_at FROM user_table_annotations_$tableId WHERE row_id = ut.id ORDER BY created_at) sub) AS cell_annotations,
+        |) FROM (SELECT column_id, uuid, langtags, type, value, annotation_name, created_at FROM user_table_annotations_$tableId WHERE row_id = ut.id ORDER BY created_at) sub) AS cell_annotations,
         |ut.row_permissions AS row_permissions""".stripMargin
   }
 

--- a/src/main/scala/com/campudus/tableaux/router/RouterRegistry.scala
+++ b/src/main/scala/com/campudus/tableaux/router/RouterRegistry.scala
@@ -39,12 +39,12 @@ object RouterRegistry extends LazyLogging {
     val fileModel = FileModel(dbConnection)
     val attachmentModel = AttachmentModel(dbConnection, fileModel)
     val serviceModel = ServiceModel(dbConnection)
-    val annotationModel = AnnotationModel(dbConnection)
+    val cellAnnotationConfigModel = CellAnnotationConfigModel(dbConnection)
 
     val systemRouter =
       SystemRouter(
         tableauxConfig,
-        SystemController(_, systemModel, tableauxModel, structureModel, serviceModel, roleModel, annotationModel)
+        SystemController(_, systemModel, tableauxModel, structureModel, serviceModel, roleModel, cellAnnotationConfigModel)
       )
     val tableauxRouter = TableauxRouter(tableauxConfig, TableauxController(_, tableauxModel, roleModel))
     val mediaRouter =

--- a/src/main/scala/com/campudus/tableaux/router/RouterRegistry.scala
+++ b/src/main/scala/com/campudus/tableaux/router/RouterRegistry.scala
@@ -44,7 +44,15 @@ object RouterRegistry extends LazyLogging {
     val systemRouter =
       SystemRouter(
         tableauxConfig,
-        SystemController(_, systemModel, tableauxModel, structureModel, serviceModel, roleModel, cellAnnotationConfigModel)
+        SystemController(
+          _,
+          systemModel,
+          tableauxModel,
+          structureModel,
+          serviceModel,
+          roleModel,
+          cellAnnotationConfigModel
+        )
       )
     val tableauxRouter = TableauxRouter(tableauxConfig, TableauxController(_, tableauxModel, roleModel))
     val mediaRouter =

--- a/src/main/scala/com/campudus/tableaux/router/RouterRegistry.scala
+++ b/src/main/scala/com/campudus/tableaux/router/RouterRegistry.scala
@@ -39,11 +39,12 @@ object RouterRegistry extends LazyLogging {
     val fileModel = FileModel(dbConnection)
     val attachmentModel = AttachmentModel(dbConnection, fileModel)
     val serviceModel = ServiceModel(dbConnection)
+    val annotationModel = AnnotationModel(dbConnection)
 
     val systemRouter =
       SystemRouter(
         tableauxConfig,
-        SystemController(_, systemModel, tableauxModel, structureModel, serviceModel, roleModel)
+        SystemController(_, systemModel, tableauxModel, structureModel, serviceModel, roleModel, annotationModel)
       )
     val tableauxRouter = TableauxRouter(tableauxConfig, TableauxController(_, tableauxModel, roleModel))
     val mediaRouter =

--- a/src/main/scala/com/campudus/tableaux/router/SystemRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/SystemRouter.scala
@@ -54,8 +54,8 @@ class SystemRouter(override val config: TableauxConfig, val controller: SystemCo
     router.get("/settings/:settings").handler(retrieveSettings)
     router.get("/services").handler(retrieveServices)
     router.getWithRegex(s"""/services/$serviceId""").handler(retrieveService)
-    router.get("/annotations").handler(retrieveAnnotations)
-    router.getWithRegex(s"""/annotations/$annotationName""").handler(retrieveAnnotation)
+    router.get("/annotations").handler(retrieveCellAnnotationConfigs)
+    router.getWithRegex(s"""/annotations/$annotationName""").handler(retrieveCellAnnotationConfig)
 
     router.deleteWithRegex(s"""/services/$serviceId""").handler(deleteService)
 
@@ -372,36 +372,36 @@ class SystemRouter(override val config: TableauxConfig, val controller: SystemCo
     }
   }
 
-  private def getAnnotationName(context: RoutingContext): Option[String] = {
+  private def getCellAnnotationConfigName(context: RoutingContext): Option[String] = {
     getStringParam("annotationName", context)
   }
 
   /**
-    * Retrieve all annotations
+    * Retrieve all cell annotation configs
     */
-  private def retrieveAnnotations(context: RoutingContext): Unit = {
+  private def retrieveCellAnnotationConfigs(context: RoutingContext): Unit = {
     implicit val user = TableauxUser(context)
     sendReply(
       context,
       asyncGetReply {
-        controller.retrieveAnnotations()
+        controller.retrieveCellAnnotationConfigs()
       }
     )
   }
 
   /**
-    * Retrieve single annotation
+    * Retrieve single cell annotation config
     */
-  private def retrieveAnnotation(context: RoutingContext): Unit = {
+  private def retrieveCellAnnotationConfig(context: RoutingContext): Unit = {
     implicit val user = TableauxUser(context)
   
     for {
-      annotationName <- getAnnotationName(context)
+      annotationName <- getCellAnnotationConfigName(context)
     } yield {
       sendReply(
         context,
         asyncGetReply {
-          controller.retrieveAnnotation(annotationName)
+          controller.retrieveCellAnnotationConfig(annotationName)
         }
       )
     }

--- a/src/main/scala/com/campudus/tableaux/router/SystemRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/SystemRouter.scala
@@ -428,7 +428,6 @@ class SystemRouter(override val config: TableauxConfig, val controller: SystemCo
           for {
             cellAnnotationConfig <- controller.deleteCellAnnotationConfig(annotationName)
           } yield {
-            // TODO: add messagingClient?
             cellAnnotationConfig
           }
         }
@@ -470,7 +469,6 @@ class SystemRouter(override val config: TableauxConfig, val controller: SystemCo
                 isDashboard
               )
           } yield {
-            // TODO: add messagingClient?
             cellAnnotationConfig
           }
         }
@@ -512,7 +510,6 @@ class SystemRouter(override val config: TableauxConfig, val controller: SystemCo
               isDashboard
             )
         } yield {
-          // TODO: add messagingClient?
           cellAnnotationConfig
         }
       }

--- a/src/main/scala/com/campudus/tableaux/router/SystemRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/SystemRouter.scala
@@ -53,7 +53,8 @@ class SystemRouter(override val config: TableauxConfig, val controller: SystemCo
     router.get("/settings/:settings").handler(retrieveSettings)
     router.get("/services").handler(retrieveServices)
     router.getWithRegex(s"""/services/$serviceId""").handler(retrieveService)
-
+    router.get("/annotations").handler(retrieveAnnotations)
+    
     router.deleteWithRegex(s"""/services/$serviceId""").handler(deleteService)
 
     router.post("/reset").handler(reset)
@@ -367,5 +368,18 @@ class SystemRouter(override val config: TableauxConfig, val controller: SystemCo
       // so nonce was used, let's invalidate it
       SystemRouter.invalidateNonce()
     }
+  }
+
+  /**
+  * Retrieve all annotations
+  */
+  private def retrieveAnnotations(context: RoutingContext): Unit = {
+    implicit val user = TableauxUser(context)
+    sendReply(
+      context,
+      asyncGetReply {
+        controller.retrieveAnnotations()
+      }
+    )
   }
 }

--- a/src/main/scala/com/campudus/tableaux/router/SystemRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/SystemRouter.scala
@@ -494,7 +494,7 @@ class SystemRouter(override val config: TableauxConfig, val controller: SystemCo
         val fgColor = json.getString("fgColor")
         val bgColor = json.getString("bgColor")
         val displayName = MultiLanguageValue[String](getNullableObject("displayName")(json))
-        
+
         // optional fields
         val priority = Try(json.getInteger("priority").intValue()).toOption
         val isMultilang = Option(json.getBoolean("isMultilang")).flatMap(Try[Boolean](_).toOption)

--- a/src/main/scala/com/campudus/tableaux/router/SystemRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/SystemRouter.scala
@@ -54,10 +54,12 @@ class SystemRouter(override val config: TableauxConfig, val controller: SystemCo
     router.get("/settings/:settings").handler(retrieveSettings)
     router.get("/services").handler(retrieveServices)
     router.getWithRegex(s"""/services/$serviceId""").handler(retrieveService)
+    
+    router.deleteWithRegex(s"""/services/$serviceId""").handler(deleteService)
+
     router.get("/annotations").handler(retrieveCellAnnotationConfigs)
     router.getWithRegex(s"""/annotations/$annotationName""").handler(retrieveCellAnnotationConfig)
-
-    router.deleteWithRegex(s"""/services/$serviceId""").handler(deleteService)
+    router.deleteWithRegex(s"""/annotations/$annotationName""").handler(deleteCellAnnotationConfig)
 
     router.post("/reset").handler(reset)
     router.post("/resetDemo").handler(resetDemo)
@@ -394,7 +396,7 @@ class SystemRouter(override val config: TableauxConfig, val controller: SystemCo
     */
   private def retrieveCellAnnotationConfig(context: RoutingContext): Unit = {
     implicit val user = TableauxUser(context)
-  
+
     for {
       annotationName <- getCellAnnotationConfigName(context)
     } yield {
@@ -402,6 +404,29 @@ class SystemRouter(override val config: TableauxConfig, val controller: SystemCo
         context,
         asyncGetReply {
           controller.retrieveCellAnnotationConfig(annotationName)
+        }
+      )
+    }
+  }
+
+  /**
+    * Delete a cell annotation config
+    */
+  private def deleteCellAnnotationConfig(context: RoutingContext): Unit = {
+    implicit val user = TableauxUser(context)
+
+    for {
+      annotationName <- getCellAnnotationConfigName(context)
+    } yield {
+      sendReply(
+        context,
+        asyncGetReply {
+          for {
+            cellAnnotationConfig <- controller.deleteCellAnnotationConfig(annotationName)
+          } yield {
+            // TODO: add messagingClient?
+            cellAnnotationConfig
+          }
         }
       )
     }

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/Action.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/Action.scala
@@ -74,3 +74,7 @@ case object ViewService extends Action { override val name = "viewService" }
 case object EditServiceDisplayProperty extends Action { override val name = "editServiceDisplayProperty" }
 case object EditServiceStructureProperty extends Action { override val name = "editServiceStructureProperty" }
 case object EditSystem extends Action { override val name = "editSystem" }
+case object CreateCellAnnotationConfig extends Action { override val name = "createCellAnnotationConfig" }
+case object DeleteCellAnnotationConfig extends Action { override val name = "deleteCellAnnotationConfig" }
+case object ViewCellAnnotationConfig extends Action { override val name = "viewCellAnnotationConfig" }
+case object EditCellAnnotationConfig extends Action { override val name = "editCellAnnotationConfig" }

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/Action.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/Action.scala
@@ -39,6 +39,10 @@ object Action {
       case EditServiceDisplayProperty.name => EditServiceDisplayProperty
       case EditServiceStructureProperty.name => EditServiceStructureProperty
       case EditSystem.name => EditSystem
+      case CreateCellAnnotationConfig.name => CreateCellAnnotationConfig
+      case DeleteCellAnnotationConfig.name => DeleteCellAnnotationConfig
+      case ViewCellAnnotationConfig.name => ViewCellAnnotationConfig
+      case EditCellAnnotationConfig.name => EditCellAnnotationConfig
       case _ => throw new IllegalArgumentException(s"Invalid argument for Action $action")
     }
   }

--- a/src/main/scala/com/campudus/tableaux/router/auth/permission/Condition.scala
+++ b/src/main/scala/com/campudus/tableaux/router/auth/permission/Condition.scala
@@ -71,7 +71,9 @@ case class ConditionContainer(
       case CreateTable | CreateMedia | EditMedia
           | DeleteMedia | CreateTableGroup | EditTableGroup | DeleteTableGroup
           | CreateService | DeleteService | ViewService | EditServiceDisplayProperty
-          | EditServiceStructureProperty | EditSystem => {
+          | EditServiceStructureProperty | EditSystem
+          | CreateCellAnnotationConfig | DeleteCellAnnotationConfig
+          | ViewCellAnnotationConfig | EditCellAnnotationConfig => {
         // global actions are already filtered by filterPermissions
         true
       }

--- a/src/test/scala/com/campudus/tableaux/api/auth/SystemControllerAuthTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/auth/SystemControllerAuthTest.scala
@@ -4,7 +4,13 @@ import com.campudus.tableaux.UnauthorizedException
 import com.campudus.tableaux.controller.SystemController
 import com.campudus.tableaux.database._
 import com.campudus.tableaux.database.domain.{DomainObject, MultiLanguageValue, ServiceTypeAction}
-import com.campudus.tableaux.database.model.{ServiceModel, StructureModel, SystemModel, TableauxModel, AnnotationModel}
+import com.campudus.tableaux.database.model.{
+  CellAnnotationConfigModel,
+  ServiceModel,
+  StructureModel,
+  SystemModel,
+  TableauxModel
+}
 import com.campudus.tableaux.router.auth.permission._
 import com.campudus.tableaux.testtools.TableauxTestBase
 
@@ -29,9 +35,17 @@ trait SystemControllerAuthTest extends TableauxTestBase {
     val structureModel = StructureModel(dbConnection)
     val tableauxModel = TableauxModel(dbConnection, structureModel, tableauxConfig)
     val serviceModel = ServiceModel(dbConnection)
-    val annotationModel = AnnotationModel(dbConnection)
+    val cellAnnotationConfigModel = CellAnnotationConfigModel(dbConnection)
 
-    SystemController(tableauxConfig, systemModel, tableauxModel, structureModel, serviceModel, roleModel, annotationModel)
+    SystemController(
+      tableauxConfig,
+      systemModel,
+      tableauxModel,
+      structureModel,
+      serviceModel,
+      roleModel,
+      cellAnnotationConfigModel
+    )
   }
 
   private def simpleDefaultService(name: String): String = s"""{

--- a/src/test/scala/com/campudus/tableaux/api/auth/SystemControllerAuthTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/auth/SystemControllerAuthTest.scala
@@ -4,7 +4,7 @@ import com.campudus.tableaux.UnauthorizedException
 import com.campudus.tableaux.controller.SystemController
 import com.campudus.tableaux.database._
 import com.campudus.tableaux.database.domain.{DomainObject, MultiLanguageValue, ServiceTypeAction}
-import com.campudus.tableaux.database.model.{ServiceModel, StructureModel, SystemModel, TableauxModel}
+import com.campudus.tableaux.database.model.{ServiceModel, StructureModel, SystemModel, TableauxModel, AnnotationModel}
 import com.campudus.tableaux.router.auth.permission._
 import com.campudus.tableaux.testtools.TableauxTestBase
 
@@ -29,8 +29,9 @@ trait SystemControllerAuthTest extends TableauxTestBase {
     val structureModel = StructureModel(dbConnection)
     val tableauxModel = TableauxModel(dbConnection, structureModel, tableauxConfig)
     val serviceModel = ServiceModel(dbConnection)
+    val annotationModel = AnnotationModel(dbConnection)
 
-    SystemController(tableauxConfig, systemModel, tableauxModel, structureModel, serviceModel, roleModel)
+    SystemController(tableauxConfig, systemModel, tableauxModel, structureModel, serviceModel, roleModel, annotationModel)
   }
 
   private def simpleDefaultService(name: String): String = s"""{

--- a/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
@@ -157,7 +157,33 @@ class SystemAnnotationTest extends TableauxTestBase {
   def updateInvalidProperty(implicit c: TestContext): Unit =
     exceptionTest("error.arguments") {
       for {
-        _ <- sendRequest("PATCH", s"/system/annotations/postpone", """{ "foo": "bar" }""")
+        _ <- sendRequest(
+          "PATCH",
+          s"/system/annotations/postpone",
+          Json.obj(
+            "foo" -> "bar"
+          ).toString()
+        )
+      } yield ()
+    }
+
+  @Test
+  def updateNoProperties(implicit c: TestContext): Unit =
+    exceptionTest("error.arguments") {
+      for {
+        _ <- sendRequest(
+          "PATCH",
+          s"/system/annotations/postpone",
+          Json.obj().toString()
+        )
+      } yield ()
+    }
+
+  @Test
+  def updateNoPayload(implicit c: TestContext): Unit =
+    exceptionTest("error.json.notfound") {
+      for {
+        _ <- sendRequest("PATCH", s"/system/annotations/postpone")
       } yield ()
     }
 
@@ -261,6 +287,25 @@ class SystemAnnotationTest extends TableauxTestBase {
             "en" -> "New"
           )
         ).toString()
+      )
+    }
+
+  @Test
+  def createWithNoProperties(implicit c: TestContext): Unit =
+    exceptionTest("error.arguments") {
+      sendRequest(
+        "POST",
+        "/system/annotations",
+        Json.obj().toString()
+      )
+    }
+
+  @Test
+  def createWithEmptyPayload(implicit c: TestContext): Unit =
+    exceptionTest("error.json.notfound") {
+      sendRequest(
+        "POST",
+        "/system/annotations"
       )
     }
 

--- a/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
@@ -17,7 +17,6 @@ class SystemAnnotationTest extends TableauxTestBase {
 
   @Test
   def retrieveAll(implicit c: TestContext): Unit = okTest {
-
     for {
       annotationConfigs <- sendRequest("GET", "/system/annotations")
     } yield {
@@ -74,9 +73,41 @@ class SystemAnnotationTest extends TableauxTestBase {
             "isMultilang" -> true,
             "isDashboard" -> true,
             "isCustom" -> false
-          ),
+          )
         ),
         annotationConfigs.getJsonArray("annotations")
+      )
+    }
+  }
+
+  // GET /system/annotations/<annotationName>
+
+  @Test
+  def retrieveSingleNonExisting(implicit c: TestContext): Unit =
+    exceptionTest("NOT FOUND") {
+      sendRequest("GET", "/system/annotations/does-not-exist")
+    }
+
+  @Test
+  def retrieveSingle(implicit c: TestContext): Unit = okTest {
+    for {
+      annotationConfig <- sendRequest("GET", "/system/annotations/postpone")
+    } yield {
+      assertJSONEquals(
+        Json.obj(
+          "name" -> "postpone",
+          "priority" -> 3,
+          "fgColor" -> "#ffffff",
+          "bgColor" -> "#999999",
+          "displayName" -> Json.obj(
+            "de" -> "Später",
+            "en" -> "Later"
+          ),
+          "isMultilang" -> false,
+          "isDashboard" -> true,
+          "isCustom" -> false
+        ),
+        annotationConfig
       )
     }
   }

--- a/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
@@ -34,7 +34,7 @@ class SystemAnnotationTest extends TableauxTestBase {
             ),
             "isMultilang" -> false,
             "isDashboard" -> true,
-            "isCustom" -> false
+            "isCustom" -> true
           ),
           Json.obj(
             "name" -> "check-me",
@@ -47,7 +47,7 @@ class SystemAnnotationTest extends TableauxTestBase {
             ),
             "isMultilang" -> false,
             "isDashboard" -> true,
-            "isCustom" -> false
+            "isCustom" -> true
           ),
           Json.obj(
             "name" -> "postpone",
@@ -60,7 +60,7 @@ class SystemAnnotationTest extends TableauxTestBase {
             ),
             "isMultilang" -> false,
             "isDashboard" -> true,
-            "isCustom" -> false
+            "isCustom" -> true
           ),
           Json.obj(
             "name" -> "needs_translation",
@@ -106,7 +106,7 @@ class SystemAnnotationTest extends TableauxTestBase {
           ),
           "isMultilang" -> false,
           "isDashboard" -> true,
-          "isCustom" -> false
+          "isCustom" -> true
         ),
         annotationConfig
       )
@@ -135,6 +135,12 @@ class SystemAnnotationTest extends TableauxTestBase {
       assertEquals(3, configsAfterDeletion.size)
     }
   }
+  
+  @Test
+  def deleteNonCustom(implicit c: TestContext): Unit =
+    exceptionTest("error.request.forbidden.cellAnnotationConfig") {
+      sendRequest("DELETE", "/system/annotations/needs_translation")
+    }
 
   // PATCH /system/annotations/<annotationName>
 

--- a/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
@@ -112,4 +112,27 @@ class SystemAnnotationTest extends TableauxTestBase {
     }
   }
 
+  // DELETE /system/annotations/<annotationName>
+
+  @Test
+  def deleteSingleNonExisting(implicit c: TestContext): Unit =
+    exceptionTest("NOT FOUND") {
+      sendRequest("DELETE", "/system/annotations/does-not-exist")
+    }
+
+  @Test
+  def deleteSingle(implicit c: TestContext): Unit = okTest {
+    for {
+      configsBeforeDeletion <- sendRequest("GET", "/system/annotations").map(_.getJsonArray("annotations"))
+
+      deleteResult <- sendRequest("DELETE", s"/system/annotations/postpone")
+
+      configsAfterDeletion <- sendRequest("GET", "/system/annotations").map(_.getJsonArray("annotations"))
+    } yield {
+      assertEquals(4, configsBeforeDeletion.size)
+      assertJSONEquals("""{  "status": "ok" }""", deleteResult.toString)
+      assertEquals(3, configsAfterDeletion.size)
+    }
+  }
+
 }

--- a/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
@@ -1,0 +1,84 @@
+package com.campudus.tableaux.api.system
+
+import com.campudus.tableaux.testtools.TableauxTestBase
+
+import io.vertx.ext.unit.TestContext
+import io.vertx.ext.unit.junit.VertxUnitRunner
+import org.vertx.scala.core.json.Json
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(classOf[VertxUnitRunner])
+class SystemAnnotationTest extends TableauxTestBase {
+
+  // GET /system/annotations
+
+  @Test
+  def retrieveAll(implicit c: TestContext): Unit = okTest {
+
+    for {
+      annotationConfigs <- sendRequest("GET", "/system/annotations")
+    } yield {
+      assertEquals(
+        Json.arr(
+          Json.obj(
+            "name" -> "important",
+            "priority" -> 1,
+            "fgColor" -> "#ffffff",
+            "bgColor" -> "#ff7474",
+            "displayName" -> Json.obj(
+              "de" -> "Wichtig",
+              "en" -> "Important"
+            ),
+            "isMultilang" -> false,
+            "isDashboard" -> true,
+            "isCustom" -> false
+          ),
+          Json.obj(
+            "name" -> "check-me",
+            "priority" -> 2,
+            "fgColor" -> "#ffffff",
+            "bgColor" -> "#c274ff",
+            "displayName" -> Json.obj(
+              "de" -> "Bitte überprüfen",
+              "en" -> "Please double-check"
+            ),
+            "isMultilang" -> false,
+            "isDashboard" -> true,
+            "isCustom" -> false
+          ),
+          Json.obj(
+            "name" -> "postpone",
+            "priority" -> 3,
+            "fgColor" -> "#ffffff",
+            "bgColor" -> "#999999",
+            "displayName" -> Json.obj(
+              "de" -> "Später",
+              "en" -> "Later"
+            ),
+            "isMultilang" -> false,
+            "isDashboard" -> true,
+            "isCustom" -> false
+          ),
+          Json.obj(
+            "name" -> "needs_translation",
+            "priority" -> 4,
+            "fgColor" -> "#ffffff",
+            "bgColor" -> "#ffae74",
+            "displayName" -> Json.obj(
+              "de" -> "Übersetzung nötig",
+              "en" -> "Translation necessary"
+            ),
+            "isMultilang" -> true,
+            "isDashboard" -> true,
+            "isCustom" -> false
+          ),
+        ),
+        annotationConfigs.getJsonArray("annotations")
+      )
+    }
+  }
+
+}

--- a/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
@@ -135,7 +135,7 @@ class SystemAnnotationTest extends TableauxTestBase {
       assertEquals(3, configsAfterDeletion.size)
     }
   }
-  
+
   @Test
   def deleteNonCustom(implicit c: TestContext): Unit =
     exceptionTest("error.request.forbidden.cellAnnotationConfig") {

--- a/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/system/SystemAnnotationTest.scala
@@ -141,7 +141,7 @@ class SystemAnnotationTest extends TableauxTestBase {
   @Test
   def updateSingleProperty(implicit c: TestContext): Unit = okTest {
     val configUpdate = Json.obj(
-      "fgColor" -> "#dddddd",
+      "fgColor" -> "#dddddd"
     ).toString();
 
     for {
@@ -181,5 +181,87 @@ class SystemAnnotationTest extends TableauxTestBase {
       assertJSONEquals(configUpdate, result.toString, JSONCompareMode.LENIENT)
     }
   }
+
+  // POST /system/annotations
+
+  @Test
+  def createWithAllProperties(implicit c: TestContext): Unit = okTest {
+    val configCreate = Json.obj(
+      "name" -> "new_annotation",
+      "priority" -> 5,
+      "fgColor" -> "#aaaaaa",
+      "bgColor" -> "#dddddd",
+      "displayName" -> Json.obj(
+        "de" -> "Neu",
+        "en" -> "New"
+      ),
+      "isMultilang" -> true,
+      "isDashboard" -> true
+    ).toString()
+
+    for {
+      annotationConfig <- sendRequest("POST", "/system/annotations", configCreate)
+    } yield {
+      assertJSONEquals(configCreate, annotationConfig.toString, JSONCompareMode.LENIENT)
+    }
+  }
+
+  @Test
+  def createWithOnlyMandatoryProperties(implicit c: TestContext): Unit = okTest {
+    val configCreate = Json.obj(
+      "name" -> "new_annotation",
+      "priority" -> 5,
+      "fgColor" -> "#aaaaaa",
+      "bgColor" -> "#dddddd",
+      "displayName" -> Json.obj(
+        "de" -> "Neu",
+        "en" -> "New"
+      )
+    ).toString()
+
+    for {
+      annotationConfig <- sendRequest("POST", "/system/annotations", configCreate)
+    } yield {
+      assertJSONEquals(configCreate, annotationConfig.toString, JSONCompareMode.LENIENT)
+    }
+  }
+
+  @Test
+  def createWithInvalidName(implicit c: TestContext): Unit =
+    exceptionTest("error.request.unique.cellAnnotationConfig") {
+      for {
+        _ <- sendRequest(
+          "POST",
+          "/system/annotations",
+          Json.obj(
+            "name" -> "postpone", // already exists
+            "priority" -> 5,
+            "fgColor" -> "#aaaaaa",
+            "bgColor" -> "#dddddd",
+            "displayName" -> Json.obj(
+              "de" -> "Neu",
+              "en" -> "New"
+            )
+          ).toString()
+        )
+      } yield ()
+    }
+
+  @Test
+  def createWithMissingMandatoryProperties(implicit c: TestContext): Unit =
+    exceptionTest("error.arguments") {
+      sendRequest(
+        "POST",
+        "/system/annotations",
+        Json.obj(
+          "fgColor" -> "#aaaaaa",
+          "bgColor" -> "#dddddd",
+          "displayName" -> Json.obj(
+            "de" -> "Neu",
+            "en" -> "New"
+          )
+        ).toString()
+      )
+    }
 
 }

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -72,8 +72,8 @@ class SystemControllerTest extends TableauxTestBase {
     okTest {
       val expectedJson = Json.obj(
         "database" -> Json.obj(
-          "current" -> 37,
-          "specification" -> 37
+          "current" -> 38,
+          "specification" -> 38
         )
       )
 

--- a/src/test/scala/com/campudus/tableaux/verticles/MessagingVerticle/MessagingVerticleTest.scala
+++ b/src/test/scala/com/campudus/tableaux/verticles/MessagingVerticle/MessagingVerticleTest.scala
@@ -5,7 +5,13 @@ import com.campudus.tableaux.cache.CacheVerticle
 import com.campudus.tableaux.controller.SystemController
 import com.campudus.tableaux.database.{DatabaseConnection, LanguageNeutral, TextType}
 import com.campudus.tableaux.database.domain._
-import com.campudus.tableaux.database.model.{ServiceModel, StructureModel, SystemModel, TableauxModel, AnnotationModel}
+import com.campudus.tableaux.database.model.{
+  CellAnnotationConfigModel,
+  ServiceModel,
+  StructureModel,
+  SystemModel,
+  TableauxModel
+}
 import com.campudus.tableaux.database.model.TableauxModel.{ColumnId, RowId, TableId}
 import com.campudus.tableaux.helper.FileUtils
 import com.campudus.tableaux.router.auth.permission.{RoleModel, TableauxUser}
@@ -189,9 +195,17 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
     val systemModel = SystemModel(dbConnection)
     val tableauxModel = TableauxModel(dbConnection, structureModel, tableauxConfig)
     val serviceModel = ServiceModel(dbConnection)
-    val annotationModel = AnnotationModel(dbConnection)
+    val cellAnnotationConfigModel = CellAnnotationConfigModel(dbConnection)
 
-    SystemController(tableauxConfig, systemModel, tableauxModel, structureModel, serviceModel, roleModel, annotationModel)
+    SystemController(
+      tableauxConfig,
+      systemModel,
+      tableauxModel,
+      structureModel,
+      serviceModel,
+      roleModel,
+      cellAnnotationConfigModel
+    )
   }
 
   def createScope(

--- a/src/test/scala/com/campudus/tableaux/verticles/MessagingVerticle/MessagingVerticleTest.scala
+++ b/src/test/scala/com/campudus/tableaux/verticles/MessagingVerticle/MessagingVerticleTest.scala
@@ -5,7 +5,7 @@ import com.campudus.tableaux.cache.CacheVerticle
 import com.campudus.tableaux.controller.SystemController
 import com.campudus.tableaux.database.{DatabaseConnection, LanguageNeutral, TextType}
 import com.campudus.tableaux.database.domain._
-import com.campudus.tableaux.database.model.{ServiceModel, StructureModel, SystemModel, TableauxModel}
+import com.campudus.tableaux.database.model.{ServiceModel, StructureModel, SystemModel, TableauxModel, AnnotationModel}
 import com.campudus.tableaux.database.model.TableauxModel.{ColumnId, RowId, TableId}
 import com.campudus.tableaux.helper.FileUtils
 import com.campudus.tableaux.router.auth.permission.{RoleModel, TableauxUser}
@@ -189,8 +189,9 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
     val systemModel = SystemModel(dbConnection)
     val tableauxModel = TableauxModel(dbConnection, structureModel, tableauxConfig)
     val serviceModel = ServiceModel(dbConnection)
+    val annotationModel = AnnotationModel(dbConnection)
 
-    SystemController(tableauxConfig, systemModel, tableauxModel, structureModel, serviceModel, roleModel)
+    SystemController(tableauxConfig, systemModel, tableauxModel, structureModel, serviceModel, roleModel, annotationModel)
   }
 
   def createScope(


### PR DESCRIPTION
Beinhaltet folgende Anpassungen:
- Neue Tabelle für die Konfiguration von Annotations  -> `system_annotations`
- DB-Migration für die 4 Standard Annotations `important`, `check-me`, `postpone`, `needs_translation`
- Endpunkte zum Abrufen, Erstellen und Löschen von Annotations inkl. Tests und Swagger-Doku -> `/system/annotations`