### PR TITLE
fix/github-artifact-workflow

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -119,9 +119,6 @@ jobs:
         with:
           path: artifacts
 
-      - name: Debug Test Results
-        run: ls -R artifacts
-
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -70,21 +70,21 @@ jobs:
 
       - name: Archive test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-report
           path: build/reports/tests/test
 
       - name: Archive test results (xml)
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: build/test-results/test/TEST-*.xml
 
       - name: Archive code coverage results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: build/reports/scoverage
@@ -115,9 +115,10 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
+          merge-multiple: true
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -117,8 +117,11 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          path: artifacts
-          merge-multiple: true
+          # pattern: test-results
+          path: artifacts/test-results
+
+      - name: Debug Test Results
+        run: ls -R artifacts
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -117,8 +117,7 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          # pattern: test-results
-          path: artifacts/test-results
+          path: artifacts
 
       - name: Debug Test Results
         run: ls -R artifacts

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -122,7 +122,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          merge-multiple: true
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -76,21 +76,21 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-report
+          name: test-report-postgres-${{ matrix.postgres-version }}
           path: build/reports/tests/test
 
       - name: Archive test results (xml)
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-postgres-${{ matrix.postgres-version }}
           path: build/test-results/test/TEST-*.xml
 
       - name: Archive code coverage results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
+          name: coverage-report-postgres-${{ matrix.postgres-version }}
           path: build/reports/scoverage
 
       - name: Test Report
@@ -121,9 +121,11 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
+          # we have to publish only one of the results of the matrix build (take postgres 16 result)
+          pattern: test-results-postgres-16
           path: artifacts
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          files: artifacts/test-results/**/*.xml
+          files: artifacts/test-results-postgres-16/**/*.xml

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -74,21 +74,21 @@ jobs:
 
       - name: Archive test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-report
           path: build/reports/tests/test
 
       - name: Archive test results (xml)
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: build/test-results/test/TEST-*.xml
 
       - name: Archive code coverage results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: build/reports/scoverage
@@ -119,9 +119,10 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
+          merge-multiple: true
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
Für branches.yml funktioniert die pipeline wieder.

Für main_ci.yml sehen wir es erst, wenn der PR erstellt wird und die pipeline läuft 🤞