### PR TITLE
AC#1137/fix/value-is-null

### DIFF
--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -44,12 +44,7 @@ class TableauxController(
       value: String
   )(implicit user: TableauxUser): Future[CellLevelAnnotation] = {
     logger.info(s"addCellAnnotation $tableId $columnId $rowId $langtags $annotationType $value")
-    checkArguments(
-      greaterZero(tableId),
-      greaterThan(columnId, -1, "columnId"),
-      greaterZero(rowId),
-      notNull(value, "value")
-    )
+    checkArguments(greaterZero(tableId), greaterThan(columnId, -1, "columnId"), greaterZero(rowId))
 
     for {
       table <- repository.retrieveTable(tableId)
@@ -59,7 +54,7 @@ class TableauxController(
           s"Cannot add an annotation with langtags to a language neutral cell (table: $tableId, column: $columnId)"
         )
       }
-      _ = if (annotationType == FlagAnnotationType && langtags.isEmpty) {
+      _ = if (annotationType == FlagAnnotationType && value == "needs_translation" && langtags.isEmpty) {
         throw UnprocessableEntityException(s"Cannot add/change an 'needs_translation' annotation without langtags")
       }
       _ <- roleModel.checkAuthorization(EditCellAnnotation, ComparisonObjects(table))

--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -43,8 +43,13 @@ class TableauxController(
       annotationType: CellAnnotationType,
       value: String
   )(implicit user: TableauxUser): Future[CellLevelAnnotation] = {
-    checkArguments(greaterZero(tableId), greaterThan(columnId, -1, "columnId"), greaterZero(rowId))
     logger.info(s"addCellAnnotation $tableId $columnId $rowId $langtags $annotationType $value")
+    checkArguments(
+      greaterZero(tableId),
+      greaterThan(columnId, -1, "columnId"),
+      greaterZero(rowId),
+      notNull(value, "value")
+    )
 
     for {
       table <- repository.retrieveTable(tableId)

--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -59,6 +59,9 @@ class TableauxController(
           s"Cannot add an annotation with langtags to a language neutral cell (table: $tableId, column: $columnId)"
         )
       }
+      _ = if (annotationType == FlagAnnotationType && langtags.isEmpty) {
+        throw UnprocessableEntityException(s"Cannot add/change an 'needs_translation' annotation without langtags")
+      }
       _ <- roleModel.checkAuthorization(EditCellAnnotation, ComparisonObjects(table))
 
       cellAnnotation <- repository.addCellAnnotation(column, rowId, langtags, annotationType, value)

--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -55,7 +55,7 @@ class TableauxController(
         )
       }
       _ = if (annotationType == FlagAnnotationType && value == "needs_translation" && langtags.isEmpty) {
-        throw UnprocessableEntityException(s"Cannot add/change an 'needs_translation' annotation without langtags")
+        throw UnprocessableEntityException(s"Cannot add/change a 'needs_translation' annotation without langtags")
       }
       _ <- roleModel.checkAuthorization(EditCellAnnotation, ComparisonObjects(table))
 

--- a/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
@@ -625,7 +625,7 @@ class CellLevelAnnotationsTest extends TableauxTestBase {
           Json.arr("en"),
           rowJson2.getJsonArray("annotations").getJsonArray(0).getJsonObject(0).getJsonArray("langtags")
         )
-        assertNull(rowJson3.getJsonArray("annotations").getJsonArray(0).getJsonObject(0))
+        assertNull(rowJson3.getJsonArray("annotations"))
       }
     }
   }

--- a/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
@@ -333,6 +333,26 @@ class CellLevelAnnotationsTest extends TableauxTestBase {
   }
 
   @Test
+  def addAnnotations_emptyLangtags(implicit c: TestContext): Unit = {
+    exceptionTest("unprocessable.entity") {
+      for {
+        tableId <- createDefaultTable("Test")
+
+        // empty row
+        result <- sendRequest("POST", s"/tables/$tableId/rows")
+        rowId = result.getLong("id")
+
+        _ <- sendRequest(
+          "POST",
+          s"/tables/$tableId/columns/1/rows/$rowId/annotations",
+          Json.obj("type" -> "flag", "value" -> "needs_translation", "langtags" -> Json.emptyArr())
+        )
+
+      } yield ()
+    }
+  }
+
+  @Test
   def addSameAnnotationsWithDifferentLangtags(implicit c: TestContext): Unit = {
     okTest {
       // Tests what happens when annotation with same type and/or value is posted multiple times.

--- a/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
@@ -317,22 +317,6 @@ class CellLevelAnnotationsTest extends TableauxTestBase {
   }
 
   @Test
-  def addInvalidAnnotations_invalidValue(implicit c: TestContext): Unit = {
-    exceptionTest("error.arguments") {
-      for {
-        (tableId, _) <- createTableWithMultilanguageColumns("Test")
-
-        // empty row
-        result <- sendRequest("POST", s"/tables/$tableId/rows")
-        rowId = result.getLong("id")
-
-        _ <- sendRequest("POST", s"/tables/$tableId/columns/1/rows/$rowId/annotations", Json.obj("type" -> "flag"))
-
-      } yield ()
-    }
-  }
-
-  @Test
   def addAnnotations_emptyLangtags(implicit c: TestContext): Unit = {
     exceptionTest("unprocessable.entity") {
       for {
@@ -477,11 +461,10 @@ class CellLevelAnnotationsTest extends TableauxTestBase {
 
         rowJsonAfterDelete <- sendRequest("GET", s"/tables/$tableId/rows/$rowId")
       } yield {
-        val exceptedFlags = Json
-          .arr(Json.obj("langtags" -> Json.arr("de", "en"), "type" -> "error", "value" -> null))
+        val exceptedFlags = Json.arr(Json.obj("langtags" -> Json.arr("de", "en"), "type" -> "error", "value" -> null))
 
-        val exceptedFlagsAfterDelete = Json
-          .arr(Json.obj("langtags" -> Json.arr("de"), "type" -> "error", "value" -> null))
+        val exceptedFlagsAfterDelete =
+          Json.arr(Json.obj("langtags" -> Json.arr("de"), "type" -> "error", "value" -> null))
 
         assertJSONEquals(exceptedFlags, rowJson.getJsonArray("annotations").getJsonArray(0))
         assertJSONEquals(exceptedFlagsAfterDelete, rowJsonAfterDelete.getJsonArray("annotations").getJsonArray(0))
@@ -574,17 +557,7 @@ class CellLevelAnnotationsTest extends TableauxTestBase {
           )
         )
 
-        assertJSONEquals(exceptedColumn1FlagsAfterDelete, rowJson2.getJsonArray("annotations").getJsonArray(0))
-        assertFalse(
-          "should not include null field",
-          rowJson2
-            .getJsonArray("annotations")
-            .getJsonArray(0)
-            .getJsonObject(0)
-            .containsKey("langtaga")
-        ); // JSON serialization from the server should not include null fields, such as "versionedFlows": null
-
-        assertNull(rowJson2.getJsonArray("annotations").getJsonArray(1))
+        assertNull(rowJson2.getJsonArray("annotations"))
       }
     }
   }

--- a/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/CellLevelAnnotationsTest.scala
@@ -301,7 +301,7 @@ class CellLevelAnnotationsTest extends TableauxTestBase {
   }
 
   @Test
-  def addInvalidAnnotations(implicit c: TestContext): Unit = {
+  def addInvalidAnnotations_invalidType(implicit c: TestContext): Unit = {
     exceptionTest("error.arguments") {
       for {
         tableId <- createDefaultTable("Test")
@@ -311,6 +311,22 @@ class CellLevelAnnotationsTest extends TableauxTestBase {
         rowId = result.getLong("id")
 
         _ <- sendRequest("POST", s"/tables/$tableId/columns/1/rows/$rowId/annotations", Json.obj("type" -> "invalid"))
+
+      } yield ()
+    }
+  }
+
+  @Test
+  def addInvalidAnnotations_invalidValue(implicit c: TestContext): Unit = {
+    exceptionTest("error.arguments") {
+      for {
+        tableId <- createDefaultTable("Test")
+
+        // empty row
+        result <- sendRequest("POST", s"/tables/$tableId/rows")
+        rowId = result.getLong("id")
+
+        _ <- sendRequest("POST", s"/tables/$tableId/columns/1/rows/$rowId/annotations", Json.obj("type" -> "flag"))
 
       } yield ()
     }


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

In diesem PR sind zwei issues zusammengefasst:
- [AC#1137](https://app.activecollab.com/116706/projects/2/tasks/61330)
- [AC#1140](https://app.activecollab.com/116706/projects/2/tasks/61428)

Beinhaltet folgende Änderungen:
 - wenn der letzte langtag in einer needs_translation gelöscht wird, wird die ganze annotation gelöscht
 - update mit einem leeren langtag array sind nicht mehr erlaubt, wenn value `needs_translation` ist