### PR TITLE
AC#1152/concat format pattern

### DIFF
--- a/src/main/resources/schema/schema_v39.sql
+++ b/src/main/resources/schema/schema_v39.sql
@@ -1,0 +1,2 @@
+ALTER TABLE system_table
+  ADD COLUMN concat_format_pattern VARCHAR(255);

--- a/src/main/resources/swagger.json
+++ b/src/main/resources/swagger.json
@@ -2636,6 +2636,11 @@
         "hidden": {
           "type": "boolean",
           "example": false
+        },
+        "concatFormatPattern": {
+          "type": "string",
+          "description": "Pattern for the frontend how to render the content of the concat column",
+          "example": "{{1}} | {{2}} | {{3}}"
         }
       }
     },

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -438,6 +438,7 @@ class StructureController(
     } yield {
       logger.info(s"retrieved table after change $changedTable")
       eventClient.tableChanged(tableId)
+      columnStruc.removeCache(table.id, None)
       changedTable
     }
   }

--- a/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/StructureController.scala
@@ -181,7 +181,16 @@ class StructureController(
     ) => {
       for {
         _ <- roleModel.checkAuthorization(CreateTable)
-        tableStub <- tableStruc.create(tableName, hidden, langtags, displayInfos, tableType, tableGroupId, attributes, concatFormatPattern)
+        tableStub <- tableStruc.create(
+          tableName,
+          hidden,
+          langtags,
+          displayInfos,
+          tableType,
+          tableGroupId,
+          attributes,
+          concatFormatPattern
+        )
         _ <- columns match {
           case None => Future.successful(())
           case Some(cols) => columnStruc.createColumns(tableStub, cols)
@@ -414,7 +423,16 @@ class StructureController(
         } else {
           Future { Unit }
         }
-      _ <- tableStruc.change(tableId, tableName, hidden, langtags, displayInfos, tableGroupId, attributes, concatFormatPattern)
+      _ <- tableStruc.change(
+        tableId,
+        tableName,
+        hidden,
+        langtags,
+        displayInfos,
+        tableGroupId,
+        attributes,
+        concatFormatPattern
+      )
       changedTable <- tableStruc.retrieve(tableId)
     } yield {
       logger.info(s"retrieved table after change $changedTable")

--- a/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/SystemController.scala
@@ -197,7 +197,7 @@ class SystemController(
     logger.info(s"createTable $tableName columns $rows")
 
     for {
-      table <- structureModel.tableStruc.create(tableName, hidden = false, None, List(), GenericTable, None, None)
+      table <- structureModel.tableStruc.create(tableName, hidden = false, None, List(), GenericTable, None, None, None)
       columns <- structureModel.columnStruc.createColumns(table, columns)
 
       columnIds = columns.map(_.id)

--- a/src/main/scala/com/campudus/tableaux/database/domain/column.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/column.scala
@@ -709,15 +709,23 @@ sealed trait ConcatenateColumn extends ColumnType[JsonArray] {
 
 case class ConcatColumn(
     override val columnInformation: ConcatColumnInformation,
-    override val columns: Seq[ColumnType[_]]
+    override val columns: Seq[ColumnType[_]],
+    formatPattern: Option[String]
 )(implicit override val roleModel: RoleModel, val user: TableauxUser) extends ConcatenateColumn {
   override val kind: ConcatType.type = ConcatType
 
-  override def getJson: JsonObject =
-    super.getJson.mergeIn(
-      Json.obj("concats" -> columns.map(_.getJson))
-    )
+  override def getJson: JsonObject = {
+    val concatsJson = Json.obj("concats" -> columns.map(_.getJson))
 
+    val formatPatternJson = formatPattern match {
+      case Some(pattern) => Json.obj("formatPattern" -> pattern)
+      case None => Json.emptyObj()
+    }
+
+    super.getJson
+      .mergeIn(concatsJson)
+      .mergeIn(formatPatternJson)
+  }
 }
 
 case class GroupColumn(

--- a/src/main/scala/com/campudus/tableaux/database/domain/table.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/table.scala
@@ -61,7 +61,7 @@ case class Table(
       "hidden" -> hidden,
       "displayName" -> Json.obj(),
       "description" -> Json.obj(),
-      "attributes" -> attributes.getOrElse(new JsonObject("{}")),
+      "attributes" -> attributes.getOrElse(new JsonObject("{}"))
     )
 
     langtags.foreach(lt => tableJson.mergeIn(Json.obj("langtags" -> lt)))

--- a/src/main/scala/com/campudus/tableaux/database/domain/table.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/table.scala
@@ -62,7 +62,6 @@ case class Table(
       "displayName" -> Json.obj(),
       "description" -> Json.obj(),
       "attributes" -> attributes.getOrElse(new JsonObject("{}")),
-      "concatFormatPattern" -> concatFormatPattern.orNull
     )
 
     langtags.foreach(lt => tableJson.mergeIn(Json.obj("langtags" -> lt)))
@@ -85,6 +84,13 @@ case class Table(
     if (tableType != GenericTable) {
       tableJson.mergeIn(Json.obj("type" -> tableType.NAME))
     }
+
+    val concatFormatPatternJson = concatFormatPattern match {
+      case Some(pattern) => Json.obj("concatFormatPattern" -> pattern)
+      case None => Json.obj()
+    }
+
+    tableJson.mergeIn(concatFormatPatternJson)
 
     tableGroup.foreach(tg => tableJson.put("group", tg.getJson))
 

--- a/src/main/scala/com/campudus/tableaux/database/domain/table.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/table.scala
@@ -38,7 +38,7 @@ case object TaxonomyTable extends TableType {
 object Table {
 
   def apply(id: TableId)(implicit roleModel: RoleModel, user: TableauxUser): Table = {
-    Table(id, "unknown", hidden = false, None, Seq.empty, GenericTable, None, None)
+    Table(id, "unknown", hidden = false, None, Seq.empty, GenericTable, None, None, None)
   }
 }
 
@@ -50,7 +50,8 @@ case class Table(
     displayInfos: Seq[DisplayInfo],
     tableType: TableType,
     tableGroup: Option[TableGroup],
-    attributes: Option[JsonObject]
+    attributes: Option[JsonObject],
+    concatFormatPattern: Option[String]
 )(implicit roleModel: RoleModel = RoleModel(), user: TableauxUser) extends DomainObject {
 
   override def getJson: JsonObject = {
@@ -60,7 +61,8 @@ case class Table(
       "hidden" -> hidden,
       "displayName" -> Json.obj(),
       "description" -> Json.obj(),
-      "attributes" -> attributes.getOrElse(new JsonObject("{}"))
+      "attributes" -> attributes.getOrElse(new JsonObject("{}")),
+      "concatFormatPattern" -> concatFormatPattern.orNull
     )
 
     langtags.foreach(lt => tableJson.mergeIn(Json.obj("langtags" -> lt)))

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -187,7 +187,8 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
     setupVersion(readSchemaFile("schema_v35"), 35),
     setupVersion(readSchemaFile("schema_v36"), 36),
     setupVersion(readSchemaFile("schema_v37"), 37),
-    setupVersion(readSchemaFile("schema_v38"), 38)
+    setupVersion(readSchemaFile("schema_v38"), 38),
+    setupVersion(readSchemaFile("schema_v39"), 39)
   )
 
   private val setupShortCutFunction: Seq[DbTransaction => Future[DbTransaction]] = Seq(

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -74,7 +74,7 @@ sealed trait StructureDelegateModel extends DatabaseQuery {
   protected[this] implicit def roleModel: RoleModel
 
   def createTable(name: String, hidden: Boolean)(implicit user: TableauxUser): Future[Table] = {
-    structureModel.tableStruc.create(name, hidden, None, List(), GenericTable, None, None)
+    structureModel.tableStruc.create(name, hidden, None, List(), GenericTable, None, None, None)
   }
 
   def retrieveTable(tableId: TableId, isInternalCall: Boolean = false)(
@@ -583,7 +583,7 @@ class TableauxModel(
   }
 
   def retrieveTablesWithCellAnnotationCount(tables: Seq[Table]): Future[Seq[TableWithCellAnnotationCount]] = {
-    val tableIds = tables.map({ case Table(id, _, _, _, _, _, _, _) => id })
+    val tableIds = tables.map({ case Table(id, _, _, _, _, _, _, _, _) => id })
 
     for {
       annotationCountMap <- retrieveRowModel.retrieveCellAnnotationCount(tableIds)

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
@@ -1003,16 +1003,17 @@ class ColumnModel(val connection: DatabaseConnection)(
   ): Seq[ColumnType[_]] = {
     val identifierColumns = columns.filter(_.identifier)
 
-    val formatPattern = if (!isColumnGroupMatchingToFormatPattern(table.concatFormatPattern, identifierColumns)) {
-      val columnsIds = identifierColumns.map(_.id).mkString(", ");
-      val formatPatternString = table.concatFormatPattern.map(_.toString).orNull;
+    val formatPattern =
+      if (!isColumnGroupMatchingToFormatPattern(table.concatFormatPattern, identifierColumns)) {
+        val columnsIds = identifierColumns.map(_.id).mkString(", ");
+        val formatPatternString = table.concatFormatPattern.map(_.toString).orNull;
 
-      logger.warn(s"IdentifierColumns ($columnsIds) don't match to formatPattern '$formatPatternString'")
+        logger.warn(s"IdentifierColumns ($columnsIds) don't match to formatPattern '$formatPatternString'")
 
-      None
-    } else {
-      table.concatFormatPattern
-    }
+        None
+      } else {
+        table.concatFormatPattern
+      }
 
     identifierColumns.size match {
       case x if x >= 2 => {

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
@@ -955,7 +955,7 @@ class ColumnModel(val connection: DatabaseConnection)(
         // select either identifier column and/or
         // ... grouped columns if GroupColumn is an identifier
         """
-          |AND identifier = TRUE OR
+          |AND (identifier = TRUE OR
           |(
           | SELECT COUNT(*)
           | FROM
@@ -965,7 +965,7 @@ class ColumnModel(val connection: DatabaseConnection)(
           | LEFT JOIN system_columns sc2
           |   ON (sc2.table_id = g.table_id AND sc2.column_id = g.group_column_id)
           | WHERE sc2.identifier = TRUE AND sc.column_id = c.column_id AND sc.table_id = c.table_id
-          |) > 0""".stripMargin
+          |) > 0)""".stripMargin
       } else {
         ""
       }

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
@@ -1007,7 +1007,7 @@ class ColumnModel(val connection: DatabaseConnection)(
       case x if x >= 2 =>
         // in case of two or more identifier columns we preserve the order of column
         // and a concatcolumn in front of all columns
-        columns.+:(ConcatColumn(ConcatColumnInformation(table), identifierColumns))
+        columns.+:(ConcatColumn(ConcatColumnInformation(table), identifierColumns, table.concatFormatPattern))
       case x if x == 1 =>
         // in case of one identifier column we don't get a concat column
         // but the identifier column will be the first

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
@@ -1004,23 +1004,11 @@ class ColumnModel(val connection: DatabaseConnection)(
   ): Seq[ColumnType[_]] = {
     val identifierColumns = columns.filter(_.identifier)
 
-    val formatPattern =
-      if (!isColumnGroupMatchingToFormatPattern(table.concatFormatPattern, identifierColumns)) {
-        val columnsIds = identifierColumns.map(_.id).mkString(", ");
-        val pattern = table.concatFormatPattern.map(_.toString).orNull;
-
-        logger.warn(s"IdentifierColumns ($columnsIds) don't match with formatPattern '$pattern'")
-
-        None
-      } else {
-        table.concatFormatPattern
-      }
-
     identifierColumns.size match {
       case x if x >= 2 => {
         // in case of two or more identifier columns we preserve the order of column
         // and a concatcolumn in front of all columns
-        columns.+:(ConcatColumn(ConcatColumnInformation(table), identifierColumns, formatPattern))
+        columns.+:(ConcatColumn(ConcatColumnInformation(table), identifierColumns, table.concatFormatPattern))
       }
       case x if x == 1 =>
         // in case of one identifier column we don't get a concat column

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/ColumnModel.scala
@@ -86,7 +86,7 @@ class CachedColumnModel(
     } yield ()
   }
 
-  private def removeCache(tableId: TableId, columnIdOpt: Option[ColumnId]): Future[Unit] = {
+  def removeCache(tableId: TableId, columnIdOpt: Option[ColumnId]): Future[Unit] = {
 
     for {
       // remove retrieveAll cache

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
@@ -424,14 +424,18 @@ class TableModel(val connection: DatabaseConnection)(
         t,
         { concatFormatPattern: String =>
           {
-            t.query(s"UPDATE system_table SET concat_format_pattern = ? WHERE table_id = ?", Json.arr(concatFormatPattern, tableId))
+            t.query(
+              s"UPDATE system_table SET concat_format_pattern = ? WHERE table_id = ?",
+              Json.arr(concatFormatPattern, tableId)
+            )
           }
         }
       )
 
       t <- insertOrUpdateTableDisplayInfo(t, tableId, displayInfos)
 
-      _ <- Future(checkUpdateResults(result1, result2, result3, result4, result5, result6)) recoverWith t.rollbackAndFail()
+      _ <-
+        Future(checkUpdateResults(result1, result2, result3, result4, result5, result6)) recoverWith t.rollbackAndFail()
 
       _ <- t.commit()
     } yield ()

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
@@ -29,7 +29,8 @@ class TableModel(val connection: DatabaseConnection)(
       displayInfos: Seq[DisplayInfo],
       tableType: TableType,
       tableGroupIdOpt: Option[TableGroupId],
-      attributes: Option[JsonObject]
+      attributes: Option[JsonObject],
+      concatFormatPattern: Option[String]
   )(
       implicit user: TableauxUser
   ): Future[Table] = {
@@ -49,7 +50,7 @@ class TableModel(val connection: DatabaseConnection)(
 
           (t, result) <- t
             .query(
-              s"INSERT INTO system_table (user_table_name, is_hidden, langtags, type, group_id, attributes) VALUES (?, ?, ?, ?, ?, ?) RETURNING table_id",
+              s"INSERT INTO system_table (user_table_name, is_hidden, langtags, type, group_id, attributes, concat_format_pattern) VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING table_id",
               Json
                 .arr(
                   name,
@@ -60,7 +61,8 @@ class TableModel(val connection: DatabaseConnection)(
                   attributes match {
                     case Some(obj) => obj.encode()
                     case None => "{}"
-                  }
+                  },
+                  concatFormatPattern.orNull
                 )
             )
           id = insertNotNull(result).head.get[TableId](0)
@@ -105,7 +107,8 @@ class TableModel(val connection: DatabaseConnection)(
             displayInfos,
             tableType,
             tableGroup,
-            attributes
+            attributes,
+            concatFormatPattern
           )
         )
       }
@@ -220,7 +223,7 @@ class TableModel(val connection: DatabaseConnection)(
       t <- connection.begin()
 
       (t, tableResult) <- t.query(
-        "SELECT table_id, user_table_name, is_hidden, array_to_json(langtags), type, group_id, attributes FROM system_table WHERE table_id = ?",
+        "SELECT table_id, user_table_name, is_hidden, array_to_json(langtags), type, group_id, attributes, concat_format_pattern FROM system_table WHERE table_id = ?",
         Json.arr(tableId)
       )
       (t, displayInfoResult) <- t.query(
@@ -251,7 +254,7 @@ class TableModel(val connection: DatabaseConnection)(
       t <- connection.begin()
 
       (t, tablesResult) <- t.query(
-        "SELECT table_id, user_table_name, is_hidden, array_to_json(langtags), type, group_id, attributes FROM system_table ORDER BY ordering, table_id"
+        "SELECT table_id, user_table_name, is_hidden, array_to_json(langtags), type, group_id, attributes, concat_format_pattern FROM system_table ORDER BY ordering, table_id"
       )
       (t, displayInfosResult) <- t.query("SELECT table_id, langtag, name, description FROM system_table_lang")
 
@@ -312,7 +315,8 @@ class TableModel(val connection: DatabaseConnection)(
       List(),
       TableType(row.getString(4)),
       Option(row.getLong(5)).map(_.longValue()).flatMap(tableGroups.get),
-      Option(row.getString(6)).map(jsonString => new JsonObject(jsonString))
+      Option(row.getString(6)).map(jsonString => new JsonObject(jsonString)),
+      Option(row.getString(7))
     )
   }
 
@@ -342,7 +346,8 @@ class TableModel(val connection: DatabaseConnection)(
       langtags: Option[Option[Seq[String]]],
       displayInfos: Option[Seq[DisplayInfo]],
       tableGroupId: Option[Option[TableGroupId]],
-      attributes: Option[JsonObject]
+      attributes: Option[JsonObject],
+      concatFormatPattern: Option[String]
   ): Future[Unit] = {
     for {
       t <- connection.begin()
@@ -414,10 +419,19 @@ class TableModel(val connection: DatabaseConnection)(
           }
         }
       )
+      (t, result6) <- optionToValidFuture(
+        concatFormatPattern,
+        t,
+        { concatFormatPattern: String =>
+          {
+            t.query(s"UPDATE system_table SET concat_format_pattern = ? WHERE table_id = ?", Json.arr(concatFormatPattern, tableId))
+          }
+        }
+      )
 
       t <- insertOrUpdateTableDisplayInfo(t, tableId, displayInfos)
 
-      _ <- Future(checkUpdateResults(result1, result2, result3, result4, result5)) recoverWith t.rollbackAndFail()
+      _ <- Future(checkUpdateResults(result1, result2, result3, result4, result5, result6)) recoverWith t.rollbackAndFail()
 
       _ <- t.commit()
     } yield ()

--- a/src/main/scala/com/campudus/tableaux/database/model/tableaux/RowModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/tableaux/RowModel.scala
@@ -985,7 +985,7 @@ class RetrieveRowModel(val connection: DatabaseConnection)(
   ): Future[Seq[TableWithCellAnnotations]] = {
     val query = tables
       .map({
-        case Table(id, _, _, _, _, _, _, _) =>
+        case Table(id, _, _, _, _, _, _, _, _) =>
           s"""SELECT
              |$id::bigint as table_id,
              |ua.row_id,

--- a/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
+++ b/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
@@ -190,7 +190,7 @@ object JsonUtils extends LazyLogging {
                   .map(_.toLong)
                   .toSeq
 
-                val formatPattern = Try(json.getString("formatPattern")).toOption
+                val formatPattern = Try(notNull(json.getString("formatPattern"), "formatPattern").get).toOption
                 val showMemberColumns = json.getBoolean("showMemberColumns", false)
 
                 CreateGroupColumn(
@@ -393,7 +393,7 @@ object JsonUtils extends LazyLogging {
     val maxLength = getNullableJsonIntegerValue("maxLength", json).toOption
     val minLength = getNullableJsonIntegerValue("minLength", json).toOption
     val decimalDigits = parseDecimalDigits(json)
-    val formatPattern = Try(json.getString("formatPattern")).toOption
+    val formatPattern = Try(notNull(json.getString("formatPattern"), "formatPattern").get).toOption
 
     (
       name,

--- a/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
+++ b/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
@@ -356,7 +356,8 @@ object JsonUtils extends LazyLogging {
       Option[Int],
       Option[Int],
       Option[Boolean],
-      Option[Int]
+      Option[Int],
+      Option[String]
   ) = {
 
     val name = Try(notNull(json.getString("name"), "name").get).toOption
@@ -392,6 +393,7 @@ object JsonUtils extends LazyLogging {
     val maxLength = getNullableJsonIntegerValue("maxLength", json).toOption
     val minLength = getNullableJsonIntegerValue("minLength", json).toOption
     val decimalDigits = parseDecimalDigits(json)
+    val formatPattern = Try(Option(json.getString("formatPattern"))).toOption.flatten
 
     (
       name,
@@ -407,7 +409,8 @@ object JsonUtils extends LazyLogging {
       maxLength,
       minLength,
       showMemberColumns,
-      decimalDigits
+      decimalDigits,
+      formatPattern
     )
   }
 

--- a/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
+++ b/src/main/scala/com/campudus/tableaux/helper/JsonUtils.scala
@@ -190,7 +190,7 @@ object JsonUtils extends LazyLogging {
                   .map(_.toLong)
                   .toSeq
 
-                val formatPattern = Try(Option(json.getString("formatPattern"))).toOption.flatten
+                val formatPattern = Try(json.getString("formatPattern")).toOption
                 val showMemberColumns = json.getBoolean("showMemberColumns", false)
 
                 CreateGroupColumn(
@@ -393,7 +393,7 @@ object JsonUtils extends LazyLogging {
     val maxLength = getNullableJsonIntegerValue("maxLength", json).toOption
     val minLength = getNullableJsonIntegerValue("minLength", json).toOption
     val decimalDigits = parseDecimalDigits(json)
-    val formatPattern = Try(Option(json.getString("formatPattern"))).toOption.flatten
+    val formatPattern = Try(json.getString("formatPattern")).toOption
 
     (
       name,

--- a/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
@@ -296,7 +296,8 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
             maxLength,
             minLength,
             showMemberColumns,
-            decimalDigits
+            decimalDigits,
+            formatPattern
           ) =
             toColumnChanges(json)
 
@@ -316,7 +317,8 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
             maxLength,
             minLength,
             showMemberColumns,
-            decimalDigits
+            decimalDigits,
+            formatPattern
           )
         }
       )

--- a/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
@@ -170,7 +170,9 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
           Option(json.getJsonArray("langtags")).map(_.asScala.map(_.toString).toSeq)
         )
         val tableGroupId = booleanToValueOption(json.containsKey("group"), json.getLong("group")).map(_.toLong)
-        controller.createTable(name, hidden, langtags, displayInfos, tableType, tableGroupId, attributes)
+        val concatFormatPattern = Option(json.getString("concatFormatPattern"))
+
+        controller.createTable(name, hidden, langtags, displayInfos, tableType, tableGroupId, attributes, concatFormatPattern)
       }
     )
   }
@@ -229,8 +231,9 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
             json.containsKey("group"),
             Option(json.getLong("group")).map(_.toLong)
           )
+          val concatFormatPattern = Option(json.getString("concatFormatPattern"))
 
-          controller.changeTable(tableId, name, hidden, langtags, displayInfos, tableGroupId, attributes)
+          controller.changeTable(tableId, name, hidden, langtags, displayInfos, tableGroupId, attributes, concatFormatPattern)
         }
       )
     }

--- a/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/StructureRouter.scala
@@ -172,7 +172,16 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
         val tableGroupId = booleanToValueOption(json.containsKey("group"), json.getLong("group")).map(_.toLong)
         val concatFormatPattern = Option(json.getString("concatFormatPattern"))
 
-        controller.createTable(name, hidden, langtags, displayInfos, tableType, tableGroupId, attributes, concatFormatPattern)
+        controller.createTable(
+          name,
+          hidden,
+          langtags,
+          displayInfos,
+          tableType,
+          tableGroupId,
+          attributes,
+          concatFormatPattern
+        )
       }
     )
   }
@@ -233,7 +242,16 @@ class StructureRouter(override val config: TableauxConfig, val controller: Struc
           )
           val concatFormatPattern = Option(json.getString("concatFormatPattern"))
 
-          controller.changeTable(tableId, name, hidden, langtags, displayInfos, tableGroupId, attributes, concatFormatPattern)
+          controller.changeTable(
+            tableId,
+            name,
+            hidden,
+            langtags,
+            displayInfos,
+            tableGroupId,
+            attributes,
+            concatFormatPattern
+          )
         }
       )
     }

--- a/src/test/scala/com/campudus/tableaux/api/auth/StructureControllerAuthTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/auth/StructureControllerAuthTest.scala
@@ -154,7 +154,8 @@ class StructureControllerTableAuthTest_checkAuthorization extends StructureContr
         displayInfos = DisplayInfos.fromJson(Json.emptyObj()),
         tableType = GenericTable,
         tableGroupId = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
     } yield {
       assertEquals(1: Long, table.id)
@@ -176,7 +177,8 @@ class StructureControllerTableAuthTest_checkAuthorization extends StructureContr
           displayInfos = DisplayInfos.fromJson(Json.emptyObj()),
           tableType = GenericTable,
           tableGroupId = None,
-          attributes = None
+          attributes = None,
+          concatFormatPattern = None
         )
       } yield ()
     }
@@ -199,7 +201,7 @@ class StructureControllerTableAuthTest_checkAuthorization extends StructureContr
     for {
       tableId <- createDefaultTable("Test")
 
-      _ <- controller.changeTable(tableId, None, None, None, Some(displayInfos), None, None)
+      _ <- controller.changeTable(tableId, None, None, None, Some(displayInfos), None, None, None)
     } yield ()
   }
 
@@ -211,7 +213,7 @@ class StructureControllerTableAuthTest_checkAuthorization extends StructureContr
 
       for {
         tableId <- createDefaultTable("Test")
-        _ <- controller.changeTable(tableId, None, None, None, Some(displayInfos), None, None)
+        _ <- controller.changeTable(tableId, None, None, None, Some(displayInfos), None, None, None)
       } yield ()
     }
 
@@ -231,7 +233,7 @@ class StructureControllerTableAuthTest_checkAuthorization extends StructureContr
 
     for {
       tableId <- createDefaultTable("Test")
-      _ <- controller.changeTable(tableId, Some("changeTableName"), None, None, None, None, None)
+      _ <- controller.changeTable(tableId, Some("changeTableName"), None, None, None, None, None, None)
     } yield ()
   }
 
@@ -253,7 +255,7 @@ class StructureControllerTableAuthTest_checkAuthorization extends StructureContr
       for {
         tableId <- createDefaultTable("Test")
 
-        _ <- controller.changeTable(tableId, Some("changeTableName"), None, None, None, None, None)
+        _ <- controller.changeTable(tableId, Some("changeTableName"), None, None, None, None, None, None)
       } yield ()
     }
 

--- a/src/test/scala/com/campudus/tableaux/api/auth/permission/PermissionTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/auth/permission/PermissionTest.scala
@@ -20,7 +20,7 @@ class PermissionTest {
       hidden: Boolean = false,
       tableType: TableType = GenericTable,
       tableGroupOpt: Option[TableGroup] = None
-  ): Table = Table(id, name, hidden, null, null, tableType, tableGroupOpt, None)
+  ): Table = Table(id, name, hidden, null, null, tableType, tableGroupOpt, None, None)
 
   private def createSimpleColumn(
       id: Long = 1,
@@ -63,7 +63,7 @@ class PermissionTest {
   @Test
   def isMatching_tablePermissionRegexAll_returnsTrue(): Unit = {
 
-    val table = Table(1, "table", hidden = false, null, null, null, null, None)
+    val table = Table(1, "table", hidden = false, null, null, null, null, None, None)
 
     val permission: Permission = Permission(defaultPermissionJson)
     Assert.assertEquals(true, permission.isMatching(ViewTable, ComparisonObjects(table)))

--- a/src/test/scala/com/campudus/tableaux/api/content/RetrieveTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/RetrieveTest.scala
@@ -50,7 +50,6 @@ class RetrieveTest extends TableauxTestBase {
         "totalSize" -> 0
       ),
       "attributes" -> Json.obj(),
-      "concatFormatPattern" -> null,
       "rows" -> Json.arr(),
       "langtags" -> Json.arr("de-DE", "en-GB"),
       "permission" -> Json.obj(

--- a/src/test/scala/com/campudus/tableaux/api/content/RetrieveTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/RetrieveTest.scala
@@ -50,6 +50,7 @@ class RetrieveTest extends TableauxTestBase {
         "totalSize" -> 0
       ),
       "attributes" -> Json.obj(),
+      "concatFormatPattern" -> null,
       "rows" -> Json.arr(),
       "langtags" -> Json.arr("de-DE", "en-GB"),
       "permission" -> Json.obj(

--- a/src/test/scala/com/campudus/tableaux/api/structure/ChangeStructureTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/ChangeStructureTest.scala
@@ -117,6 +117,17 @@ class ChangeStructureTest extends TableauxTestBase {
   }
 
   @Test
+  def changeColumnFormatPatternForbiddenForNonGroupColumns(implicit c: TestContext): Unit =
+    exceptionTest("error.request.forbidden.column") {
+      val postJson = Json.obj("formatPattern" -> "{{1}} {{2}}")
+
+      for {
+        _ <- createDefaultTable()
+        resultPost <- sendRequest("POST", "/tables/1/columns/2", postJson)
+      } yield ()
+    }
+
+  @Test
   def changeColumnKindWhichShouldFail(implicit c: TestContext): Unit = {
     okTest {
       val kindTextJson = Json.obj("kind" -> "text")

--- a/src/test/scala/com/campudus/tableaux/api/structure/TableConcatFormatPatternTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/TableConcatFormatPatternTest.scala
@@ -1,0 +1,121 @@
+package com.campudus.tableaux.api.structure
+
+import com.campudus.tableaux.testtools.TableauxTestBase
+
+import io.vertx.ext.unit.TestContext
+import io.vertx.ext.unit.junit.VertxUnitRunner
+import org.vertx.scala.core.json.Json
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(classOf[VertxUnitRunner])
+class TableConcatFormatPatternTest extends TableauxTestBase {
+
+  @Test
+  def createRegularTable(implicit c: TestContext): Unit = okTest {
+    val createTableJson = Json.obj("name" -> "Regular table test")
+    val expectedTableJson = Json.obj(
+      "status" -> "ok",
+      "id" -> 1,
+      "name" -> "Regular table test",
+      "hidden" -> false,
+      "displayName" -> Json.obj(),
+      "description" -> Json.obj(),
+      "langtags" -> Json.arr("de-DE", "en-GB")
+    )
+
+    for {
+      tablePost <- sendRequest("POST", "/tables", createTableJson)
+      tableId = tablePost.getLong("id").toLong
+      tableGet <- sendRequest("GET", s"/tables/$tableId")
+    } yield {
+      assertJSONEquals(expectedTableJson, tablePost)
+      assertJSONEquals(expectedTableJson, tableGet)
+    }
+  }
+
+  @Test
+  def createRegularTableWithConcatFormatPattern(implicit c: TestContext): Unit = okTest {
+    val createTableJson = Json.obj("name" -> "concatFormatPattern test", "concatFormatPattern" -> "{{1}} | {{2}}")
+    val expectedTableJson = Json.obj(
+      "status" -> "ok",
+      "id" -> 1,
+      "name" -> "concatFormatPattern test",
+      "hidden" -> false,
+      "displayName" -> Json.obj(),
+      "description" -> Json.obj(),
+      "langtags" -> Json.arr("de-DE", "en-GB"),
+      "concatFormatPattern" -> "{{1}} | {{2}}"
+    )
+
+    for {
+      tablePost <- sendRequest("POST", "/tables", createTableJson)
+      tableId = tablePost.getLong("id").toLong
+      tableGet <- sendRequest("GET", s"/tables/$tableId")
+    } yield {
+      assertJSONEquals(expectedTableJson, tablePost)
+      assertJSONEquals(expectedTableJson, tableGet)
+    }
+  }
+
+  @Test
+  def updateTableNameDoesNotChangeConcatFormatPattern(implicit c: TestContext): Unit = {
+    okTest {
+      val createTableJson = Json.obj("name" -> "concatFormatPattern test", "concatFormatPattern" -> "{{1}} | {{2}}")
+      val updateTableJson = Json.obj("name" -> "Still concatFormatPattern test")
+      val expectedTableJson = Json.obj(
+        "status" -> "ok",
+        "id" -> 1,
+        "name" -> "Still concatFormatPattern test",
+        "hidden" -> false,
+        "displayName" -> Json.obj(),
+        "description" -> Json.obj(),
+        "langtags" -> Json.arr("de-DE", "en-GB"),
+        "concatFormatPattern" -> "{{1}} | {{2}}"
+      )
+
+      for {
+        tablePost <- sendRequest("POST", "/tables", createTableJson)
+        tableId = tablePost.getLong("id").toLong
+        tableUpdate <- sendRequest("POST", s"/tables/$tableId", updateTableJson)
+        table <- sendRequest("GET", s"/tables/$tableId")
+      } yield {
+        assertJSONEquals(expectedTableJson, tableUpdate)
+        assertJSONEquals(expectedTableJson, table)
+      }
+    }
+  }
+
+  @Test
+  def updateTableConcatFormatPattern(implicit c: TestContext): Unit = okTest {
+    val createTableJson = Json.obj("name" -> "concatFormatPattern test", "concatFormatPattern" -> "{{1}} | {{2}}")
+    val updateTableJson = Json.obj("concatFormatPattern" -> "{{1}} | {{2}} | {{3}}")
+    val expectedTableJson = Json.obj(
+      "status" -> "ok",
+      "id" -> 1,
+      "name" -> "concatFormatPattern test",
+      "hidden" -> false,
+      "displayName" -> Json.obj(),
+      "description" -> Json.obj(),
+      "langtags" -> Json.arr("de-DE", "en-GB")
+    )
+    val expectedTableJson1 = expectedTableJson.copy().mergeIn(Json.obj("concatFormatPattern" -> "{{1}} | {{2}}"))
+    val expectedTableJson2 =
+      expectedTableJson.copy().mergeIn(Json.obj("concatFormatPattern" -> "{{1}} | {{2}} | {{3}}"))
+
+    for {
+      tablePost <- sendRequest("POST", "/tables", createTableJson)
+      tableId = tablePost.getLong("id").toLong
+      table1 <- sendRequest("GET", s"/tables/$tableId")
+      tableUpdate <- sendRequest("POST", s"/tables/$tableId", updateTableJson)
+      table2 <- sendRequest("GET", s"/tables/$tableId")
+    } yield {
+      assertJSONEquals(expectedTableJson1, tablePost)
+      assertJSONEquals(expectedTableJson1, table1)
+      assertJSONEquals(expectedTableJson2, tableUpdate)
+      assertJSONEquals(expectedTableJson2, table2)
+    }
+  }
+
+}

--- a/src/test/scala/com/campudus/tableaux/api/structure/TableConcatFormatPatternTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/structure/TableConcatFormatPatternTest.scala
@@ -13,29 +13,6 @@ import org.junit.runner.RunWith
 class TableConcatFormatPatternTest extends TableauxTestBase {
 
   @Test
-  def createRegularTable(implicit c: TestContext): Unit = okTest {
-    val createTableJson = Json.obj("name" -> "Regular table test")
-    val expectedTableJson = Json.obj(
-      "status" -> "ok",
-      "id" -> 1,
-      "name" -> "Regular table test",
-      "hidden" -> false,
-      "displayName" -> Json.obj(),
-      "description" -> Json.obj(),
-      "langtags" -> Json.arr("de-DE", "en-GB")
-    )
-
-    for {
-      tablePost <- sendRequest("POST", "/tables", createTableJson)
-      tableId = tablePost.getLong("id").toLong
-      tableGet <- sendRequest("GET", s"/tables/$tableId")
-    } yield {
-      assertJSONEquals(expectedTableJson, tablePost)
-      assertJSONEquals(expectedTableJson, tableGet)
-    }
-  }
-
-  @Test
   def createRegularTableWithConcatFormatPattern(implicit c: TestContext): Unit = okTest {
     val createTableJson = Json.obj("name" -> "concatFormatPattern test", "concatFormatPattern" -> "{{1}} | {{2}}")
     val expectedTableJson = Json.obj(

--- a/src/test/scala/com/campudus/tableaux/controller/StructureControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/StructureControllerTest.scala
@@ -38,7 +38,8 @@ class StructureControllerTest extends TableauxTestBase {
         displayInfos = null,
         tableType = GenericTable,
         tableGroupId = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
     )
   }

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -72,8 +72,8 @@ class SystemControllerTest extends TableauxTestBase {
     okTest {
       val expectedJson = Json.obj(
         "database" -> Json.obj(
-          "current" -> 38,
-          "specification" -> 38
+          "current" -> 39,
+          "specification" -> 39
         )
       )
 

--- a/src/test/scala/com/campudus/tableaux/database/model/structure/ColumnModelTest.scala
+++ b/src/test/scala/com/campudus/tableaux/database/model/structure/ColumnModelTest.scala
@@ -75,11 +75,11 @@ class ColumnModelTest {
   }
 
   @Test
-  def isColumnGroupMatchingToFormatPattern_twoColumns_oneWildcards_isNotValid(): Unit = {
+  def isColumnGroupMatchingToFormatPattern_twoColumns_oneWildcards_isValid(): Unit = {
     val formatPattern = "{{1}} mm"
     val columns = Seq(col1, col2)
 
-    assertFalse(isColumnGroupMatchingToFormatPattern(Some(formatPattern), columns))
+    assertTrue(isColumnGroupMatchingToFormatPattern(Some(formatPattern), columns))
   }
 
   @Test

--- a/src/test/scala/com/campudus/tableaux/database/model/structure/ColumnModelTest.scala
+++ b/src/test/scala/com/campudus/tableaux/database/model/structure/ColumnModelTest.scala
@@ -20,7 +20,7 @@ class ColumnModelTest {
     val sc1 = CreateSimpleColumn("c1", null, null, LanguageNeutral, identifier = false, Nil, separator = false, None)
     val sc2 = CreateSimpleColumn("c2", null, null, LanguageNeutral, identifier = false, Nil, separator = false, None)
 
-    val testTable = Table(1, "table", hidden = false, null, null, null, null, None)
+    val testTable = Table(1, "table", hidden = false, null, null, null, null, None, None)
     val bci1 = BasicColumnInformation(testTable, 1, 1, null, sc1)
     val bci2 = BasicColumnInformation(testTable, 2, 1, null, sc2)
 
@@ -109,7 +109,7 @@ class ColumnModelTest {
   def isColumnGroupMatchingToFormatPattern_oneHigherColumnId_patternWithHigherWildcard_isValid(): Unit = {
     val sc42 =
       CreateSimpleColumn("c42", null, null, LanguageNeutral, identifier = false, List(), separator = false, None)
-    val testTable = Table(1, "table", hidden = false, null, null, null, null, None)
+    val testTable = Table(1, "table", hidden = false, null, null, null, null, None, None)
     val bci42 = BasicColumnInformation(testTable, 42, 1, null, sc42)
 
     val col42 = SimpleValueColumn(ShortTextType, LanguageNeutral, bci42)

--- a/src/test/scala/com/campudus/tableaux/verticles/MessagingVerticleTest.scala
+++ b/src/test/scala/com/campudus/tableaux/verticles/MessagingVerticleTest.scala
@@ -308,7 +308,8 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
         displayInfos = Seq(),
         tableType = GenericTable,
         tableGroupIdOpt = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
 
       _ <- eventClient.tableCreated(table.id)
@@ -334,7 +335,8 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
         displayInfos = Seq(),
         tableType = GenericTable,
         tableGroupIdOpt = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
       _ <- structureModel.tableStruc.delete(table.id)
       _ <- eventClient.tableDeleted(table.id, table)
@@ -359,11 +361,13 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
         displayInfos = Seq(),
         tableType = GenericTable,
         tableGroupIdOpt = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
       _ <- structureModel.tableStruc.change(
         table.id,
         Some("test_table_1_updated"),
+        None,
         None,
         None,
         None,
@@ -403,7 +407,8 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
         displayInfos = Seq(),
         tableType = GenericTable,
         tableGroupIdOpt = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
       column <- structureModel.columnStruc.createColumn(table, columnToCreate)
       _ <- eventClient.columnCreated(table.id, column.id)
@@ -449,7 +454,8 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
         displayInfos = Seq(),
         tableType = GenericTable,
         tableGroupIdOpt = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
       column <- structureModel.columnStruc.createColumn(table, columnToCreate)
       _ <- structureModel.columnStruc.createColumn(table, columnToCreate2)
@@ -487,7 +493,8 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
         displayInfos = Seq(),
         tableType = GenericTable,
         tableGroupIdOpt = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
       column <- structureModel.columnStruc.createColumn(table, columnToCreate)
       updatedColumn <-
@@ -536,7 +543,8 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
         displayInfos = Seq(),
         tableType = GenericTable,
         tableGroupIdOpt = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
       column <- structureModel.columnStruc.createColumn(table, defaultColumnToCreate)
     } yield (table, column)
@@ -659,7 +667,8 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
         displayInfos = Seq(),
         tableType = GenericTable,
         tableGroupIdOpt = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
       linkColumn <- structureModel.columnStruc.createColumn(table2, linkColumnToCreate)
       createdRowTable2 <- tableauxModel.createRow(table2, None)
@@ -798,7 +807,8 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
         displayInfos = Seq(),
         tableType = GenericTable,
         tableGroupIdOpt = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
       // listener should be selected
       nonIdentifierNonHiddenTableColumn <-
@@ -817,7 +827,8 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
         displayInfos = Seq(),
         tableType = GenericTable,
         tableGroupIdOpt = None,
-        attributes = None
+        attributes = None,
+        concatFormatPattern = None
       )
       // listener should NOT be selected
       nonIdentifierHiddenTableColumn <-

--- a/src/test/scala/com/campudus/tableaux/verticles/MessagingVerticleTest.scala
+++ b/src/test/scala/com/campudus/tableaux/verticles/MessagingVerticleTest.scala
@@ -514,6 +514,7 @@ class MessagingVerticleTest extends TableauxTestBase with MockitoSugar {
           None,
           None,
           None,
+          None,
           None
         )
       _ <- eventClient.columnChanged(table.id, updatedColumn.id)


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true

 - [x] I gave the PR a meaningful name
 - [x] I checked that the correct target branch is selected
 - [x] I rebased the branch on the target branch and it can be merged
 - [x] I ran the linter and it did pass
 - [x] I checked for unused code / dead code / debug code
 - [x] I checked that variables/functions have meaningful names
 - [x] I checked that the behaviour is as the documentation/task describes and I tested it
 - [x] I updated the docs / specifications if possible
 - [x] I could explain all that code when someone wakes me up at 3am
 - [x] I checked that the code considers failures and not just the happy path
 - [x] There are no new dependencies OR I listed them and explained them below
 - [x] PR introduces no breaking changes OR I listed them and described them below
 - [x] I added/updated tests for new/modified unit-testable functions/helpers
 - [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

Beinhaltet die Backend-Anpassungen zu [#1152: Formatpatterns bei concat-columns/links](https://app.activecollab.com/116706/projects/2/tasks/61988):

- Tabelle (DB + API) erweitern um Property concatFormatPattern
- concatFormatPattern wird im Backend an Concat-Spalte gepackt
    - nur bei validem Pattern (Spalten im Pattern === Identifier-Spalten)
    - ansonsten Warning im Backend

Und ->  [#803: 'formatPattern' soll bei Group-Columns über die API änderbar sein.](https://app.activecollab.com/116706/projects/2/tasks/6407)
