### PR TITLE
AC#1164/history-by-column

### DIFF
--- a/src/main/resources/swagger.json
+++ b/src/main/resources/swagger.json
@@ -1276,6 +1276,32 @@
         }
       }
     },
+    "/tables/{tableId}/history": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/tableId"
+        },
+        {
+          "$ref": "#/parameters/historyType"
+        }
+      ],
+      "get": {
+        "summary": "Retrieves the history entries of a table",
+        "description": "Returns the history entries of a table.",
+        "tags": [
+          "history"
+        ],
+        "operationId": "retrieve-table-history-cell",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/history-cell"
+          },
+          "404": {
+            "$ref": "#/responses/not-found-in-database"
+          }
+        }
+      }
+    },
     "/tables/{tableId}/history/{languageTag}": {
       "parameters": [
         {
@@ -1294,7 +1320,36 @@
         "tags": [
           "history"
         ],
-        "operationId": "retrieve-table-history-cell",
+        "operationId": "retrieve-table-history-cell-language-tag",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/history-cell"
+          },
+          "404": {
+            "$ref": "#/responses/not-found-in-database"
+          }
+        }
+      }
+    },
+    "/tables/{tableId}/rows/{rowId}/history": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/tableId"
+        },
+        {
+          "$ref": "#/parameters/rowId"
+        },
+        {
+          "$ref": "#/parameters/historyType"
+        }
+      ],
+      "get": {
+        "summary": "Retrieves the history entries of a row",
+        "description": "Returns the history entries of a row.",
+        "tags": [
+          "history"
+        ],
+        "operationId": "retrieve-row-history-cell",
         "responses": {
           "200": {
             "$ref": "#/responses/history-cell"
@@ -1326,7 +1381,100 @@
         "tags": [
           "history"
         ],
-        "operationId": "retrieve-row-history-cell",
+        "operationId": "retrieve-row-history-cell-language-tag",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/history-cell"
+          },
+          "404": {
+            "$ref": "#/responses/not-found-in-database"
+          }
+        }
+      }
+    },
+    "/tables/{tableId}/columns/{columnId}/history": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/tableId"
+        },
+        {
+          "$ref": "#/parameters/columnId"
+        },
+        {
+          "$ref": "#/parameters/historyType"
+        }
+      ],
+      "get": {
+        "summary": "Retrieves the history entries of a cell",
+        "description": "Returns the history entries of a specified cell.",
+        "tags": [
+          "history"
+        ],
+        "operationId": "retrieve-column-history-cell",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/history-cell"
+          },
+          "404": {
+            "$ref": "#/responses/not-found-in-database"
+          }
+        }
+      }
+    },
+    "/tables/{tableId}/columns/{columnId}/history/{languageTag}": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/tableId"
+        },
+        {
+          "$ref": "#/parameters/columnId"
+        },
+        {
+          "$ref": "#/parameters/languageTagOpt"
+        },
+        {
+          "$ref": "#/parameters/historyType"
+        }
+      ],
+      "get": {
+        "summary": "Retrieves the history entries of a cell",
+        "description": "Returns the history entries of a specified cell.",
+        "tags": [
+          "history"
+        ],
+        "operationId": "retrieve-column-history-cell-language-tag",
+        "responses": {
+          "200": {
+            "$ref": "#/responses/history-cell"
+          },
+          "404": {
+            "$ref": "#/responses/not-found-in-database"
+          }
+        }
+      }
+    },
+    "/tables/{tableId}/columns/{columnId}/rows/{rowId}/history": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/tableId"
+        },
+        {
+          "$ref": "#/parameters/columnId"
+        },
+        {
+          "$ref": "#/parameters/rowId"
+        },
+        {
+          "$ref": "#/parameters/historyType"
+        }
+      ],
+      "get": {
+        "summary": "Retrieves the history entries of a cell",
+        "description": "Returns the history entries of a specified cell.",
+        "tags": [
+          "history"
+        ],
+        "operationId": "retrieve-cell-history-cell",
         "responses": {
           "200": {
             "$ref": "#/responses/history-cell"
@@ -1361,7 +1509,7 @@
         "tags": [
           "history"
         ],
-        "operationId": "retrieve-cell-history-cell",
+        "operationId": "retrieve-cell-history-cell-language-tag",
         "responses": {
           "200": {
             "$ref": "#/responses/history-cell"

--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -634,6 +634,21 @@ class TableauxController(
     } yield SeqHistory(historySequence)
   }
 
+  def retrieveColumnHistory(
+      tableId: TableId,
+      columnId: ColumnId,
+      langtagOpt: Option[Langtag],
+      typeOpt: Option[String]
+  )(implicit user: TableauxUser): Future[SeqHistory] = {
+    checkArguments(greaterZero(tableId), greaterThan(columnId, -1, "columnId"))
+    logger.info(s"retrieveColumnHistory $tableId $columnId $langtagOpt $typeOpt")
+
+    for {
+      table <- repository.retrieveTable(tableId)
+      historySequence <- repository.retrieveColumnHistory(table, columnId, langtagOpt, typeOpt)
+    } yield SeqHistory(historySequence)
+  }
+
   def retrieveRowHistory(
       tableId: TableId,
       rowId: RowId,

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -1602,6 +1602,20 @@ class TableauxModel(
     } yield cellHistorySeq
   }
 
+  def retrieveColumnHistory(
+      table: Table,
+      columnId: ColumnId,
+      langtagOpt: Option[String],
+      typeOpt: Option[String]
+  )(implicit user: TableauxUser): Future[Seq[History]] = {
+    for {
+      column <- retrieveColumn(table, columnId)
+      _ <- checkColumnTypeForLangtag(column, langtagOpt)
+      _ <- roleModel.checkAuthorization(ViewCellValue, ComparisonObjects(table, column))
+      columnHistorySeq <- retrieveHistoryModel.retrieveColumn(table, column, langtagOpt, typeOpt)
+    } yield columnHistorySeq
+  }
+
   def retrieveRowHistory(
       table: Table,
       rowId: RowId,

--- a/src/test/scala/com/campudus/tableaux/api/content/RetrieveHistoryTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/RetrieveHistoryTest.scala
@@ -252,6 +252,48 @@ class RetrieveHistoryTest extends TableauxTestBase {
     }
   }
 
+  @Test
+  def retrieveColumnHistory(implicit c: TestContext): Unit = {
+    okTest {
+      val sqlConnection = SQLConnection(this.vertxAccess(), databaseConfig)
+      val dbConnection = DatabaseConnection(this.vertxAccess(), sqlConnection)
+
+      for {
+        _ <- createEmptyDefaultTable()
+
+        // manually insert rows
+        _ <- dbConnection.query(
+          """INSERT INTO
+            |  user_table_history_1
+            |  (row_id, column_id, event, history_type, value_type, language_type, value)
+            |VALUES
+            |  (1, null, 'row_created',      'row',    null,               null,       null),
+            |  (1, 1,    'cell_changed',     'cell',  'numeric',           'language', '{"value": {"de": "change2"}}'),
+            |  (1, 2,    'annotation_added', 'cell',  'needs_translation', 'language', '{"value":{"de":"needs_translation"}, "uuid":"9f4eef42-0476-44d8-ae10-0cdfd802a292"}'),
+            |  (2, null, 'row_created',      'row',    null,               null,       null),
+            |  (2, 1,    'cell_changed',     'cell',  'numeric',           'language', '{"value": {"de": "change5"}}'),
+            |  (2, 2,    'annotation_added', 'cell',  'needs_translation', 'language', '{"value":{"de":"needs_translation"}, "uuid":"e3d371a4-e3cc-4697-83fe-ef32bcddd3e6"}')
+            |  """.stripMargin
+        )
+
+        allRows <- sendRequest("GET", "/tables/1/history").map(_.getJsonArray("rows"))
+        createdRows <- sendRequest("GET", "/tables/1/columns/1/history?historyType=row").map(_.getJsonArray("rows"))
+        columnHistory <- sendRequest("GET", "/tables/1/columns/1/history").map(_.getJsonArray("rows"))
+        changedCells <- sendRequest("GET", "/tables/1/columns/1/history?historyType=cell").map(_.getJsonArray("rows"))
+        addedAnnotations <-
+          sendRequest("GET", "/tables/1/columns/1/history?historyType=annotation_added").map(_.getJsonArray("rows"))
+
+      } yield {
+        assertEquals(6, allRows.size())
+        // historyType=row makes no sense for columns endpoint, so it should return empty
+        assertEquals(0, createdRows.size())
+        assertEquals(2, columnHistory.size())
+        assertEquals(1, changedCells.size())
+        assertEquals(1, addedAnnotations.size())
+      }
+    }
+  }
+
   def filterByType(historyType: String)(jsonArray: JsonArray): Seq[JsonObject] = {
     import scala.collection.JavaConverters._
 


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

Ist ziemlich viel Text für die an sich kleine Erweiterung. Ich hab im swagger auch die EPs dupliziert, weil path params nicht wirklich optional sein können, heißt wenn man den languageTag garnicht mitangeben will, ging das per swagger requests leider nicht. Jetzt kann man dafür einfach die EPs ohne die path params verwenden. Für die normale API Nutzung hat das aber keine Auswirkungen.