### PR TITLE
GRUD_DEV-1134/history-soft-delete

### DIFF
--- a/src/main/resources/schema/schema_v40.sql
+++ b/src/main/resources/schema/schema_v40.sql
@@ -6,8 +6,54 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
-SELECT add_deleted_at_column(table_id)
-FROM system_table;
-
+SELECT add_deleted_at_column(table_id) FROM system_table;
 DROP FUNCTION add_deleted_at_column( BIGINT );
 
+
+CREATE OR REPLACE FUNCTION change_history_currency_zero_values_to_null(tableid BIGINT)
+  RETURNS TEXT AS $$
+DECLARE
+  tablename TEXT := 'user_table_history_' || tableid;
+  query TEXT;
+
+BEGIN
+  query := FORMAT($f$
+    UPDATE %I AS t
+    SET value = jsonb_set(t.value::jsonb,
+                          ARRAY['value', sub.key],
+                          'null'::jsonb)
+    FROM (
+      SELECT revision, key
+      FROM %I,
+      LATERAL jsonb_each(value::jsonb -> 'value') AS v(key, val)
+      WHERE value_type = 'currency' AND val = '0'
+    ) AS sub
+    WHERE t.revision = sub.revision
+  $f$, tablename, tablename);
+
+  EXECUTE query;
+  RETURN tablename;
+END
+$$ LANGUAGE plpgsql;
+
+SELECT change_history_currency_zero_values_to_null(table_id) FROM system_table;
+DROP FUNCTION change_history_currency_zero_values_to_null( BIGINT );
+
+
+CREATE OR REPLACE FUNCTION add_indexes_to_history_table(tableid BIGINT)
+  RETURNS TEXT AS $$
+DECLARE
+  tablename TEXT := 'user_table_history_' || tableid;
+  query TEXT;
+
+BEGIN
+  EXECUTE 'CREATE INDEX idx_user_table_history_' || tableid || '_row_id ON user_table_history_' || tableid || '(row_id)';
+  EXECUTE 'CREATE INDEX idx_user_table_history_' || tableid || '_col_id ON user_table_history_' || tableid || '(column_id)';
+  EXECUTE 'CREATE INDEX idx_user_table_history_' || tableid || '_row_col_id ON user_table_history_' || tableid || '(row_id, column_id)';
+
+  RETURN 'user_table_history_' || tableid::TEXT;
+END
+$$ LANGUAGE plpgsql;
+
+SELECT add_indexes_to_history_table(table_id) FROM system_table;
+DROP FUNCTION add_indexes_to_history_table( BIGINT );

--- a/src/main/resources/schema/schema_v40.sql
+++ b/src/main/resources/schema/schema_v40.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION add_deleted_at_column(tableid BIGINT)
+  RETURNS TEXT AS $$
+BEGIN
+  EXECUTE 'ALTER TABLE user_table_history_' || tableid || ' ADD COLUMN deleted_at timestamp without time zone';
+  RETURN 'user_table_history_' || tableid :: TEXT;
+END
+$$ LANGUAGE plpgsql;
+
+SELECT add_deleted_at_column(table_id)
+FROM system_table;
+
+DROP FUNCTION add_deleted_at_column( BIGINT );
+

--- a/src/main/resources/schema/schema_v40.sql
+++ b/src/main/resources/schema/schema_v40.sql
@@ -57,3 +57,20 @@ $$ LANGUAGE plpgsql;
 
 SELECT add_indexes_to_history_table(table_id) FROM system_table;
 DROP FUNCTION add_indexes_to_history_table( BIGINT );
+
+CREATE OR REPLACE FUNCTION migrate_json_to_jsonb(tableid BIGINT)
+  RETURNS TEXT AS $$
+DECLARE
+  tablename TEXT := 'user_table_history_' || tableid;
+
+BEGIN
+  EXECUTE FORMAT($f$
+    ALTER TABLE %I ALTER COLUMN value TYPE jsonb USING value::jsonb
+  $f$, tablename);
+
+  RETURN tablename;
+END
+$$ LANGUAGE plpgsql;
+
+SELECT migrate_json_to_jsonb(table_id) FROM system_table;
+DROP FUNCTION migrate_json_to_jsonb( BIGINT );

--- a/src/main/resources/swagger.json
+++ b/src/main/resources/swagger.json
@@ -1356,6 +1356,9 @@
         },
         {
           "$ref": "#/parameters/historyType"
+        },
+        {
+          "$ref": "#/parameters/includeDeleted"
         }
       ],
       "get": {
@@ -1385,6 +1388,9 @@
         },
         {
           "$ref": "#/parameters/historyType"
+        },
+        {
+          "$ref": "#/parameters/includeDeleted"
         }
       ],
       "get": {
@@ -1414,6 +1420,9 @@
         },
         {
           "$ref": "#/parameters/historyType"
+        },
+        {
+          "$ref": "#/parameters/includeDeleted"
         }
       ],
       "get": {
@@ -1446,6 +1455,9 @@
         },
         {
           "$ref": "#/parameters/historyType"
+        },
+        {
+          "$ref": "#/parameters/includeDeleted"
         }
       ],
       "get": {
@@ -1475,6 +1487,9 @@
         },
         {
           "$ref": "#/parameters/historyType"
+        },
+        {
+          "$ref": "#/parameters/includeDeleted"
         }
       ],
       "get": {
@@ -1507,6 +1522,9 @@
         },
         {
           "$ref": "#/parameters/historyType"
+        },
+        {
+          "$ref": "#/parameters/includeDeleted"
         }
       ],
       "get": {
@@ -1539,6 +1557,9 @@
         },
         {
           "$ref": "#/parameters/historyType"
+        },
+        {
+          "$ref": "#/parameters/includeDeleted"
         }
       ],
       "get": {
@@ -1574,6 +1595,9 @@
         },
         {
           "$ref": "#/parameters/historyType"
+        },
+        {
+          "$ref": "#/parameters/includeDeleted"
         }
       ],
       "get": {
@@ -2946,7 +2970,8 @@
         "event",
         "historyType",
         "author",
-        "timestamp"
+        "timestamp",
+        "deletedAt"
       ],
       "properties": {
         "author": {
@@ -2958,6 +2983,11 @@
           "description": "The id of the column",
           "type": "integer",
           "example": 1
+        },
+        "deletedAt": {
+          "description": "Timestamp of the deletion",
+          "type": "string",
+          "example": "2025-05-06T11:42:00+01:00"
         },
         "event": {
           "description": "The event of the change",
@@ -4771,6 +4801,15 @@
       "required": true,
       "type": "string",
       "example": "postpone"
+    },
+    "includeDeleted": {
+      "name": "includeDeleted",
+      "description": "Filter to include deleted entities. (default: false)",
+      "in": "query",
+      "type": "boolean",
+      "required": false,
+      "default": false,
+      "example": true
     }
   },
   "responses": {

--- a/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
+++ b/src/main/scala/com/campudus/tableaux/controller/TableauxController.scala
@@ -624,14 +624,15 @@ class TableauxController(
       columnId: ColumnId,
       rowId: RowId,
       langtagOpt: Option[Langtag],
-      typeOpt: Option[String]
+      typeOpt: Option[String],
+      includeDeleted: Boolean = false
   )(implicit user: TableauxUser): Future[SeqHistory] = {
     checkArguments(greaterZero(tableId), greaterThan(columnId, -1, "columnId"), greaterZero(rowId))
     logger.info(s"retrieveCellHistory $tableId $columnId $rowId $langtagOpt $typeOpt")
 
     for {
       table <- repository.retrieveTable(tableId)
-      historySequence <- repository.retrieveCellHistory(table, columnId, rowId, langtagOpt, typeOpt)
+      historySequence <- repository.retrieveCellHistory(table, columnId, rowId, langtagOpt, typeOpt, includeDeleted)
     } yield SeqHistory(historySequence)
   }
 
@@ -639,14 +640,15 @@ class TableauxController(
       tableId: TableId,
       columnId: ColumnId,
       langtagOpt: Option[Langtag],
-      typeOpt: Option[String]
+      typeOpt: Option[String],
+      includeDeleted: Boolean = false
   )(implicit user: TableauxUser): Future[SeqHistory] = {
     checkArguments(greaterZero(tableId), greaterThan(columnId, -1, "columnId"))
     logger.info(s"retrieveColumnHistory $tableId $columnId $langtagOpt $typeOpt")
 
     for {
       table <- repository.retrieveTable(tableId)
-      historySequence <- repository.retrieveColumnHistory(table, columnId, langtagOpt, typeOpt)
+      historySequence <- repository.retrieveColumnHistory(table, columnId, langtagOpt, typeOpt, includeDeleted)
     } yield SeqHistory(historySequence)
   }
 
@@ -654,14 +656,15 @@ class TableauxController(
       tableId: TableId,
       rowId: RowId,
       langtagOpt: Option[Langtag],
-      typeOpt: Option[String]
+      typeOpt: Option[String],
+      includeDeleted: Boolean = false
   )(implicit user: TableauxUser): Future[SeqHistory] = {
     checkArguments(greaterZero(tableId), greaterZero(rowId))
     logger.info(s"retrieveRowHistory $tableId $rowId $langtagOpt $typeOpt")
 
     for {
       table <- repository.retrieveTable(tableId)
-      historySequence <- repository.retrieveRowHistory(table, rowId, langtagOpt, typeOpt)
+      historySequence <- repository.retrieveRowHistory(table, rowId, langtagOpt, typeOpt, includeDeleted)
     } yield {
       SeqHistory(historySequence)
     }
@@ -670,14 +673,15 @@ class TableauxController(
   def retrieveTableHistory(
       tableId: TableId,
       langtagOpt: Option[Langtag],
-      typeOpt: Option[String]
+      typeOpt: Option[String],
+      includeDeleted: Boolean = false
   )(implicit user: TableauxUser): Future[SeqHistory] = {
     checkArguments(greaterZero(tableId))
     logger.info(s"retrieveTableHistory $tableId $typeOpt")
 
     for {
       table <- repository.retrieveTable(tableId)
-      historySequence <- repository.retrieveTableHistory(table, langtagOpt, typeOpt)
+      historySequence <- repository.retrieveTableHistory(table, langtagOpt, typeOpt, includeDeleted)
     } yield SeqHistory(historySequence)
   }
 

--- a/src/main/scala/com/campudus/tableaux/database/domain/history.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/history.scala
@@ -52,15 +52,19 @@ case class BaseHistory(
 ) extends History {
 
   override def getJson: JsonObject = {
+    val deletedAtJson = optionToString(deletedAt) match {
+      case null => Json.emptyObj()
+      case v => Json.obj("deletedAt" -> v)
+    }
+
     Json.obj(
       "revision" -> revision,
       "rowId" -> rowId,
       "event" -> event,
       "historyType" -> historyType.toString,
       "author" -> author,
-      "timestamp" -> optionToString(timestamp),
-      "deletedAt" -> optionToString(deletedAt)
-    )
+      "timestamp" -> optionToString(timestamp)
+    ).mergeIn(deletedAtJson)
   }
 
   override val columnIdOpt: Option[ColumnId] = None

--- a/src/main/scala/com/campudus/tableaux/database/domain/history.scala
+++ b/src/main/scala/com/campudus/tableaux/database/domain/history.scala
@@ -25,9 +25,10 @@ object History {
       languageType: LanguageType,
       author: String,
       timestamp: Option[DateTime],
-      value: JsonObject
+      value: JsonObject,
+      deletedAt: Option[DateTime]
   ): History = {
-    val baseHistory = BaseHistory(revision, rowId, event, historyType, author, timestamp)
+    val baseHistory = BaseHistory(revision, rowId, event, historyType, author, timestamp, deletedAt)
     historyType match {
       case HistoryTypeCell | HistoryTypeCellComment =>
         CellHistory(baseHistory, columnId, valueType, languageType, value)
@@ -46,7 +47,8 @@ case class BaseHistory(
     event: String,
     historyType: HistoryType,
     author: String,
-    timestamp: Option[DateTime]
+    timestamp: Option[DateTime],
+    deletedAt: Option[DateTime]
 ) extends History {
 
   override def getJson: JsonObject = {
@@ -56,7 +58,8 @@ case class BaseHistory(
       "event" -> event,
       "historyType" -> historyType.toString,
       "author" -> author,
-      "timestamp" -> optionToString(timestamp)
+      "timestamp" -> optionToString(timestamp),
+      "deletedAt" -> optionToString(deletedAt)
     )
   }
 

--- a/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/SystemModel.scala
@@ -188,7 +188,8 @@ class SystemModel(override protected[this] val connection: DatabaseConnection) e
     setupVersion(readSchemaFile("schema_v36"), 36),
     setupVersion(readSchemaFile("schema_v37"), 37),
     setupVersion(readSchemaFile("schema_v38"), 38),
-    setupVersion(readSchemaFile("schema_v39"), 39)
+    setupVersion(readSchemaFile("schema_v39"), 39),
+    setupVersion(readSchemaFile("schema_v40"), 40)
   )
 
   private val setupShortCutFunction: Seq[DbTransaction => Future[DbTransaction]] = Seq(

--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -1584,7 +1584,8 @@ class TableauxModel(
       columnId: ColumnId,
       rowId: RowId,
       langtagOpt: Option[String],
-      typeOpt: Option[String]
+      typeOpt: Option[String],
+      includeDeleted: Boolean
   )(implicit user: TableauxUser): Future[Seq[History]] = {
     for {
       _ <-
@@ -1599,7 +1600,7 @@ class TableauxModel(
       column <- retrieveColumn(table, columnId)
       _ <- checkColumnTypeForLangtag(column, langtagOpt)
       _ <- roleModel.checkAuthorization(ViewCellValue, ComparisonObjects(table, column))
-      cellHistorySeq <- retrieveHistoryModel.retrieveCell(table, column, rowId, langtagOpt, typeOpt)
+      cellHistorySeq <- retrieveHistoryModel.retrieveCell(table, column, rowId, langtagOpt, typeOpt, includeDeleted)
     } yield cellHistorySeq
   }
 
@@ -1607,13 +1608,14 @@ class TableauxModel(
       table: Table,
       columnId: ColumnId,
       langtagOpt: Option[String],
-      typeOpt: Option[String]
+      typeOpt: Option[String],
+      includeDeleted: Boolean
   )(implicit user: TableauxUser): Future[Seq[History]] = {
     for {
       column <- retrieveColumn(table, columnId)
       _ <- checkColumnTypeForLangtag(column, langtagOpt)
       _ <- roleModel.checkAuthorization(ViewCellValue, ComparisonObjects(table, column))
-      columnHistorySeq <- retrieveHistoryModel.retrieveColumn(table, column, langtagOpt, typeOpt)
+      columnHistorySeq <- retrieveHistoryModel.retrieveColumn(table, column, langtagOpt, typeOpt, includeDeleted)
     } yield columnHistorySeq
   }
 
@@ -1621,7 +1623,8 @@ class TableauxModel(
       table: Table,
       rowId: RowId,
       langtagOpt: Option[String],
-      typeOpt: Option[String]
+      typeOpt: Option[String],
+      includeDeleted: Boolean
   )(implicit user: TableauxUser): Future[Seq[History]] = {
     for {
       _ <-
@@ -1634,17 +1637,17 @@ class TableauxModel(
           Future.successful(())
         }
       columns <- retrieveColumns(table)
-      cellHistorySeq <- retrieveHistoryModel.retrieveRow(table, rowId, langtagOpt, typeOpt)
+      cellHistorySeq <- retrieveHistoryModel.retrieveRow(table, rowId, langtagOpt, typeOpt, includeDeleted)
       filteredCellHistorySeq = filterCellHistoriesForColumns(cellHistorySeq, columns)
     } yield filteredCellHistorySeq
   }
 
-  def retrieveTableHistory(table: Table, langtagOpt: Option[String], typeOpt: Option[String])(
+  def retrieveTableHistory(table: Table, langtagOpt: Option[String], typeOpt: Option[String], includeDeleted: Boolean)(
       implicit user: TableauxUser
   ): Future[Seq[History]] = {
     for {
       columns <- retrieveColumns(table)
-      cellHistorySeq <- retrieveHistoryModel.retrieveTable(table, langtagOpt, typeOpt)
+      cellHistorySeq <- retrieveHistoryModel.retrieveTable(table, langtagOpt, typeOpt, includeDeleted)
       filteredCellHistorySeq = filterCellHistoriesForColumns(cellHistorySeq, columns)
     } yield filteredCellHistorySeq
   }

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
@@ -185,7 +185,7 @@ class TableModel(val connection: DatabaseConnection)(
            |  language_type VARCHAR(255) DEFAULT 'neutral',
            |  author VARCHAR(255),
            |  timestamp TIMESTAMP WITHOUT TIME ZONE DEFAULT now(),
-           |  value JSON NULL,
+           |  value JSONB,
            |  deleted_at timestamp without time zone,
            |
            |  PRIMARY KEY (revision)

--- a/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/structure/TableModel.scala
@@ -181,6 +181,8 @@ class TableModel(val connection: DatabaseConnection)(
                            |   author VARCHAR(255),
                            |   timestamp TIMESTAMP WITHOUT TIME ZONE DEFAULT now(),
                            |   value JSON NULL,
+                           |   deleted_at timestamp without time zone,
+                           |
                            |   PRIMARY KEY (revision)
                            | )
            """.stripMargin)

--- a/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
+++ b/src/main/scala/com/campudus/tableaux/router/TableauxRouter.scala
@@ -411,11 +411,12 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
       columnId <- getColumnId(context)
       rowId <- getRowId(context)
       typeOpt = getStringParam("historyType", context)
+      includeDeleted = getBoolParam("includeDeleted", context).getOrElse(false)
     } yield {
       sendReply(
         context,
         asyncGetReply {
-          controller.retrieveCellHistory(tableId, columnId, rowId, None, typeOpt)
+          controller.retrieveCellHistory(tableId, columnId, rowId, None, typeOpt, includeDeleted)
         }
       )
     }
@@ -432,11 +433,12 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
       rowId <- getRowId(context)
       langtag <- getLangtag(context)
       typeOpt = getStringParam("historyType", context)
+      includeDeleted = getBoolParam("includeDeleted", context).getOrElse(false)
     } yield {
       sendReply(
         context,
         asyncGetReply {
-          controller.retrieveCellHistory(tableId, columnId, rowId, Some(langtag), typeOpt)
+          controller.retrieveCellHistory(tableId, columnId, rowId, Some(langtag), typeOpt, includeDeleted)
         }
       )
     }
@@ -451,11 +453,12 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
       tableId <- getTableId(context)
       columnId <- getColumnId(context)
       typeOpt = getStringParam("historyType", context)
+      includeDeleted = getBoolParam("includeDeleted", context).getOrElse(false)
     } yield {
       sendReply(
         context,
         asyncGetReply {
-          controller.retrieveColumnHistory(tableId, columnId, None, typeOpt)
+          controller.retrieveColumnHistory(tableId, columnId, None, typeOpt, includeDeleted)
         }
       )
     }
@@ -471,11 +474,12 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
       columnId <- getColumnId(context)
       langtag <- getLangtag(context)
       typeOpt = getStringParam("historyType", context)
+      includeDeleted = getBoolParam("includeDeleted", context).getOrElse(false)
     } yield {
       sendReply(
         context,
         asyncGetReply {
-          controller.retrieveColumnHistory(tableId, columnId, Some(langtag), typeOpt)
+          controller.retrieveColumnHistory(tableId, columnId, Some(langtag), typeOpt, includeDeleted)
         }
       )
     }
@@ -490,11 +494,12 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
       tableId <- getTableId(context)
       rowId <- getRowId(context)
       typeOpt = getStringParam("historyType", context)
+      includeDeleted = getBoolParam("includeDeleted", context).getOrElse(false)
     } yield {
       sendReply(
         context,
         asyncGetReply {
-          controller.retrieveRowHistory(tableId, rowId, None, typeOpt)
+          controller.retrieveRowHistory(tableId, rowId, None, typeOpt, includeDeleted)
         }
       )
     }
@@ -510,11 +515,12 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
       rowId <- getRowId(context)
       langtag <- getLangtag(context)
       typeOpt = getStringParam("historyType", context)
+      includeDeleted = getBoolParam("includeDeleted", context).getOrElse(false)
     } yield {
       sendReply(
         context,
         asyncGetReply {
-          controller.retrieveRowHistory(tableId, rowId, Some(langtag), typeOpt)
+          controller.retrieveRowHistory(tableId, rowId, Some(langtag), typeOpt, includeDeleted)
         }
       )
     }
@@ -528,11 +534,12 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
     for {
       tableId <- getTableId(context)
       typeOpt = getStringParam("historyType", context)
+      includeDeleted = getBoolParam("includeDeleted", context).getOrElse(false)
     } yield {
       sendReply(
         context,
         asyncGetReply {
-          controller.retrieveTableHistory(tableId, None, typeOpt)
+          controller.retrieveTableHistory(tableId, None, typeOpt, includeDeleted)
         }
       )
     }
@@ -547,11 +554,12 @@ class TableauxRouter(override val config: TableauxConfig, val controller: Tablea
       tableId <- getTableId(context)
       langtag <- getLangtag(context)
       typeOpt = getStringParam("historyType", context)
+      includeDeleted = getBoolParam("includeDeleted", context).getOrElse(false)
     } yield {
       sendReply(
         context,
         asyncGetReply {
-          controller.retrieveTableHistory(tableId, Some(langtag), typeOpt)
+          controller.retrieveTableHistory(tableId, Some(langtag), typeOpt, includeDeleted)
         }
       )
     }

--- a/src/test/scala/com/campudus/tableaux/api/content/RetrieveHistoryTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/RetrieveHistoryTest.scala
@@ -202,6 +202,9 @@ class RetrieveHistoryTest extends TableauxTestBase {
         assertEquals(6, allRows.size())
         assertEquals(2, createdRows.size())
         assertEquals(4, changedCells.size())
+
+        val deletedRowResult = createdRows.getJsonObject(0)
+        assertFalse(deletedRowResult.containsKey("deletedAt"))
       }
     }
   }
@@ -224,6 +227,22 @@ class RetrieveHistoryTest extends TableauxTestBase {
         assertEquals(9, allRows.size())
         assertEquals(3, createdRows.size())
         assertEquals(6, changedCells.size())
+
+        val deletedRowResult = createdRows.getJsonObject(2)
+        assertJSONEquals(
+          """
+            |{
+            |  "revision": 7,
+            |  "rowId": 3,
+            |  "event": "row_created",
+            |  "historyType": "row",
+            |}
+          """.stripMargin,
+          deletedRowResult,
+          JSONCompareMode.LENIENT
+        )
+        assertTrue(deletedRowResult.containsKey("deletedAt"))
+        assertNotNull(deletedRowResult.getString("deletedAt"))
       }
     }
   }

--- a/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
+++ b/src/test/scala/com/campudus/tableaux/controller/SystemControllerTest.scala
@@ -72,8 +72,8 @@ class SystemControllerTest extends TableauxTestBase {
     okTest {
       val expectedJson = Json.obj(
         "database" -> Json.obj(
-          "current" -> 39,
-          "specification" -> 39
+          "current" -> 40,
+          "specification" -> 40
         )
       )
 

--- a/src/test/scala/com/campudus/tableaux/testtools/TestAssertionHelper.scala
+++ b/src/test/scala/com/campudus/tableaux/testtools/TestAssertionHelper.scala
@@ -35,13 +35,13 @@ trait TestAssertionHelper {
     assertEquals(indices.length, indices.distinct.length)
   }
 
-  def assertJSONEquals[T: JsonAssertable](
+  def assertJSONEquals[T: JsonAssertable, U: JsonAssertable](
       expected: T,
-      actual: T,
+      actual: U,
       compareMode: JSONCompareMode = JSONCompareMode.LENIENT
   ) {
     val expectedString = implicitly[JsonAssertable[T]].serialize(expected)
-    val actualString = implicitly[JsonAssertable[T]].serialize(actual)
+    val actualString = implicitly[JsonAssertable[U]].serialize(actual)
 
     JSONAssert.assertEquals(expectedString, actualString, compareMode)
   }


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

Der PR beinhaltet:
- column in history für soft delete (deleted_at)
- Filter in den EPs, um auch gelöschte Histories abfragen zu können (per default sind die herausgefiltert)
- Tests für die EPs gibt es nur exemplarisch in `table/history`, weil das das nur Duplizierung wäre und das where stmt zentral in einer eigenen Funktion zusammengebaut wird
- Migration für currency history mit `0`-Werten -> `null`
- Erzeugung von Indizes für history tables. Ich hab dafür dieses Schema file "gekapert", damit wir nicht noch ein weiteres benötigen, und das mit gemacht. Richtig viel bringt es nicht. Bei großen Tabellen, die sehr volatile Daten haben, merkt man aber schon einen Unterschied ([GRUD_DEV-989](https://campudus.myjetbrains.com/youtrack/issue/GRUD_DEV-989))
- MIgration der history value Spalte von json to jsonb ([GRUD_DEV-1142](https://campudus.myjetbrains.com/youtrack/issue/GRUD_DEV-1142))