### PR TITLE
GRUD_DEV-554/fix annotation in duplicate row result

### DIFF
--- a/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
+++ b/src/main/scala/com/campudus/tableaux/database/model/TableauxModel.scala
@@ -1380,15 +1380,15 @@ class TableauxModel(
 
       _ <- createHistoryModel.createRow(table, duplicatedRowId, Option(row.rowPermissions.value))
       _ <- createHistoryModel.createCells(table, rowId, columnsToDuplicate.zip(rowValues))
-
-      // Retrieve duplicated row with all columns
-      duplicatedRow <- retrieveRow(table, duplicatedRowId)
       _ <-
         if (shouldAnnotateSkipped) {
           Future.sequence(skippedColumns.filter(canBeDuplicated).map(col =>
-            addCellAnnotation(col, duplicatedRow.id, Seq.empty, CellAnnotationType(CellAnnotationType.FLAG), "check-me")
+            addCellAnnotation(col, duplicatedRowId, Seq.empty, CellAnnotationType(CellAnnotationType.FLAG), "check-me")
           ))
         } else Future.successful(())
+
+      // Retrieve duplicated row with all columns
+      duplicatedRow <- retrieveRow(table, duplicatedRowId)
     } yield duplicatedRow
   }
 

--- a/src/test/scala/com/campudus/tableaux/api/content/DuplicateRowTest.scala
+++ b/src/test/scala/com/campudus/tableaux/api/content/DuplicateRowTest.scala
@@ -241,10 +241,9 @@ class DuplicateRowTest extends TableauxTestBase {
     for {
       tableIds <- createLinkedTables()
       modelTableId = tableIds(0)
-      _ <- sendRequest("POST", s"/tables/$modelTableId/rows/1/duplicate?skipConstrainedLinks=true&annotateSkipped=true")
-      res <- sendRequest("GET", s"/tables/$modelTableId/columns/3/rows/3/annotations")
+      rowRes <- sendRequest("POST", s"/tables/$modelTableId/rows/1/duplicate?skipConstrainedLinks=true&annotateSkipped=true")
     } yield {
-      val checkMeAnnotation = res.getJsonArray("annotations").getJsonArray(0).getJsonObject(0)
+      val checkMeAnnotation = rowRes.getJsonArray("annotations").getJsonArray(2).getJsonObject(0)
       assertEquals(checkMeAnnotation.getString("type"), CellAnnotationType.FLAG)
       assertEquals(checkMeAnnotation.getString("value"), "check-me")
     }


### PR DESCRIPTION
# Submit a pull request

## Please make sure the following is true

- [x] I gave the PR a meaningful name
- [x] I checked that the correct target branch is selected
- [x] I rebased the branch on the target branch and it can be merged
- [x] I ran the linter and it did pass
- [x] I checked for unused code / dead code / debug code
- [x] I checked that variables/functions have meaningful names
- [x] I checked that the behaviour is as the documentation/task describes and I tested it
- [x] I updated the docs / specifications if possible
- [x] I could explain all that code when someone wakes me up at 3am
- [x] I checked that the code considers failures and not just the happy path
- [x] There are no new dependencies OR I listed them and explained them below
- [x] PR introduces no breaking changes OR I listed them and described them below
- [x] I added/updated tests for new/modified unit-testable functions/helpers
- [x] I ran the tests and they did pass

## Other information/comments (e.g. reasons why points are not checked from above)

## Reason for this PR

Bisher wurde die Annotation die für den Skip von constrained Links gesetzt wurde, nicht im Result des duplicate Row Endpoints mitgeliefert. Im Fix wird diese Annotation direkt mitgeliefert, damit kein separater Request notwendig ist um die Annotation abzuholen.